### PR TITLE
fix(swarm): stop Critic parser leaks, dedup issues, reject empty PRs

### DIFF
--- a/src/android_rpg_sdlc.py
+++ b/src/android_rpg_sdlc.py
@@ -27,6 +27,7 @@ from src.state import StateManager
 from src.tools.dispatcher import register_tool
 from src.tools.filesystem import read_file, write_file, list_directory
 from src.tools.github_tool import read_repo_file, list_repo_contents, GitHubTool
+from src.tools.content_guards import is_low_value_content
 from src.tools.web_search import search_web
 
 register_tool("search_web", search_web)
@@ -220,6 +221,23 @@ class AndroidRPGBuilder:
         cid = spec["id"]
         branch = f"{BRANCH_PREFIX}/{cid}-{int(time.time())}"
         code = read_file(f"src/staged_agents/{artifact}") if os.path.exists(f"src/staged_agents/{artifact}") else ""
+
+        # Empty-content guard: don't commit+PR a stub. This prevents the
+        # "Turn-Based Combat System" case where the RPG engine generated an
+        # empty .kt file and the PR body was literally "the code snippet is
+        # empty. Let me first check if there are any files..."
+        if is_low_value_content(code):
+            logger.warning(
+                "_deliver: skipping low-value RPG artifact %s (%d bytes)",
+                artifact,
+                len(code or ""),
+            )
+            self.sm.set_task(
+                f"rpg-{cid}",
+                {"status": "SKIPPED_LOW_VALUE", "artifact": artifact},
+                agent="Builder",
+            )
+            return None
 
         # Commit to repo — place in correct Android path
         remote_path = spec["files"][0]  # Use first file path from spec

--- a/src/autonomous_sdlc.py
+++ b/src/autonomous_sdlc.py
@@ -30,6 +30,7 @@ from src.services.workflow_graphs import (
 )
 from src.state import StateManager
 from src.tools.github_tool import GitHubTool
+from src.tools.content_guards import is_low_value_content
 from src.tools.filesystem import read_file, write_file
 from src.planner import run_planner, run_planner_structured
 
@@ -282,6 +283,24 @@ class AutonomousSDLCEngine:
         logger.info("=== DELIVER: pushing to repo ===")
         task_id = task["task_id"]
         code = read_file(artifact_path)
+
+        # Empty-content guard: don't open a PR for a stub or empty file.
+        # This stops the "Turn-Based Combat System" pattern where an empty
+        # .kt gets committed and a PR is raised whose own body admits
+        # "the code snippet is empty".
+        if is_low_value_content(code):
+            logger.warning(
+                "_deliver: skipping low-value artifact %s (%d bytes)",
+                artifact_path,
+                len(code or ""),
+            )
+            self.sm.set_task(
+                task_id,
+                {"status": "SKIPPED_LOW_VALUE", "artifact": artifact_path},
+                agent="Builder",
+            )
+            return None
+
         # Use unique branch name with timestamp to avoid collisions
         branch = f"bot/{task_id}-{int(time.time())}"
         filename = os.path.basename(artifact_path)

--- a/src/tools/content_guards.py
+++ b/src/tools/content_guards.py
@@ -1,0 +1,199 @@
+"""
+Content guards for agent-generated artifacts before they reach GitHub.
+
+These guards stop three classes of garbage that the swarm has been producing:
+
+1. **Critic parser leakage** — the Critic's LLM occasionally returns raw
+   tool-call JSON (``[{"action": "list_repo_contents", ...}]``) instead of
+   narrative review text. That JSON currently ends up verbatim in PR bodies
+   and tracking issues.
+
+2. **Low-value / empty artifacts** — Builder sometimes produces an empty
+   Kotlin file or a single-line stub and the pipeline still opens a PR of it
+   (see project-chimera PR #159 "Turn-Based Combat System" whose own body
+   reads ``"the code snippet is empty. Let me first check..."``).
+
+3. **Duplicate issues** — ``create_issue`` has no dedup; seven identical
+   "[SWARM TASK] Implement Property-Based Testing" tickets can be filed in
+   60 seconds (see project-chimera #127–#133).
+
+Everything here is a pure function with no I/O, so it's trivially unit-
+testable and safe to call on every agent output.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from typing import Iterable
+
+# ---------------------------------------------------------------------------
+# 1. Sanitize agent review text (strip tool-call JSON leakage)
+# ---------------------------------------------------------------------------
+
+#: Marker inserted when the review is discarded. Callers can grep for this
+#: in logs and metrics to count how often the bug is firing.
+LEAKED_REVIEW_PLACEHOLDER = (
+    "_(review suppressed: critic returned tool-call JSON instead of prose; "
+    "rerun critic with stricter system prompt)_"
+)
+
+_STUB_THINKING_FRAGMENTS = (
+    "the code snippet is empty",
+    "let me first check if there are any files",
+    "i'll review the kotlin",  # partial — caught in normalized lowercase
+    "review completed and saved to",  # the agent's "I saved the review elsewhere" sidestep
+)
+
+_TOOL_CALL_KEYS = ("action", "tool_name", "tool_args", "arguments")
+
+
+def _strip_code_fence(text: str) -> str:
+    """Remove a single leading/trailing ``` fence if the entire text is one fenced block."""
+    t = text.strip()
+    if t.startswith("```"):
+        # drop first line (``` or ```json etc.) and trailing fence if present
+        first_nl = t.find("\n")
+        if first_nl != -1:
+            t = t[first_nl + 1 :]
+        if t.rstrip().endswith("```"):
+            t = t.rstrip()[: -3].rstrip()
+    return t.strip()
+
+
+def _looks_like_tool_call_json(text: str) -> bool:
+    """True iff ``text`` parses as JSON and contains tool-call shaped keys."""
+    stripped = _strip_code_fence(text)
+    if not stripped or stripped[0] not in "[{":
+        return False
+    try:
+        parsed = json.loads(stripped)
+    except (ValueError, TypeError):
+        return False
+
+    def _has_tool_call_keys(obj) -> bool:
+        if isinstance(obj, dict):
+            return any(k in obj for k in _TOOL_CALL_KEYS)
+        if isinstance(obj, list):
+            return any(_has_tool_call_keys(item) for item in obj)
+        return False
+
+    return _has_tool_call_keys(parsed)
+
+
+def sanitize_review(text: str | None) -> str:
+    """Return narrative review text, or a placeholder if the input is leakage.
+
+    Specifically we replace the review when:
+
+    * the whole payload is tool-call-shaped JSON (possibly fenced with ```),
+    * the payload is only a thinking-fragment like "the code snippet is empty",
+    * the payload is empty / whitespace only.
+
+    We do NOT try to extract "partial prose" from a mixed leak — if the
+    critic produced something we can't trust, we'd rather lose the review
+    than ship JSON into an issue body.
+    """
+    if text is None:
+        return LEAKED_REVIEW_PLACEHOLDER
+
+    stripped = text.strip()
+    if not stripped:
+        return LEAKED_REVIEW_PLACEHOLDER
+
+    if _looks_like_tool_call_json(stripped):
+        return LEAKED_REVIEW_PLACEHOLDER
+
+    lowered = stripped.lower()
+    if any(frag in lowered for frag in _STUB_THINKING_FRAGMENTS):
+        return LEAKED_REVIEW_PLACEHOLDER
+
+    return stripped
+
+
+# ---------------------------------------------------------------------------
+# 2. Detect low-value / empty Builder artifacts before they reach a PR
+# ---------------------------------------------------------------------------
+
+#: Default minimum bytes of non-trivial content before an artifact is allowed
+#: to become a PR. Kotlin stubs like ``class X {}\n`` are ~14 bytes, so 80 is
+#: a deliberate floor — any real implementation clears it.
+DEFAULT_MIN_BYTES = 80
+
+# Patterns that mean "the generator gave up and emitted a placeholder"
+_STUB_BODY_PATTERNS = (
+    re.compile(r"^\s*(//|#)\s*todo\s*$", re.IGNORECASE | re.MULTILINE),
+    re.compile(r"^\s*pass\s*$", re.MULTILINE),
+)
+
+
+def _strip_comments_and_blanks(text: str) -> str:
+    """Remove // and # line comments plus blank lines, for content-size scoring."""
+    lines = []
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        if line.startswith("//") or line.startswith("#"):
+            continue
+        lines.append(line)
+    return "\n".join(lines)
+
+
+def is_low_value_content(text: str | None, *, min_bytes: int = DEFAULT_MIN_BYTES) -> bool:
+    """True if ``text`` is too empty / stubby / placeholder-only to ship.
+
+    Used by the SDLC pipelines to bail out before committing code and opening
+    a PR. The test strips comments and blanks first so ``"// TODO\\nclass X\\n"``
+    is still caught as low-value.
+    """
+    if text is None:
+        return True
+    if len(text.strip()) == 0:
+        return True
+
+    # Catch the "// TODO" / "pass" sole-content case explicitly even if
+    # padded out with comments.
+    stripped_body = _strip_comments_and_blanks(text)
+    if len(stripped_body) < min_bytes:
+        return True
+
+    for pat in _STUB_BODY_PATTERNS:
+        # If the body (after comment/blank strip) is just a stub statement, kill it.
+        if pat.search(stripped_body) and len(stripped_body) < min_bytes * 2:
+            return True
+
+    return False
+
+
+# ---------------------------------------------------------------------------
+# 3. Dedup signature for "have we already filed this issue?"
+# ---------------------------------------------------------------------------
+
+_WHITESPACE_RUN = re.compile(r"\s+")
+
+
+def _normalize_title(title: str) -> str:
+    """Lowercase + collapse whitespace so trivial drift doesn't defeat dedup."""
+    return _WHITESPACE_RUN.sub(" ", title.strip().lower())
+
+
+def issue_signature(title: str, body: str | None = None) -> str:
+    """Stable SHA-256 of the normalized title (and optional body prefix).
+
+    We dedup primarily on title because the body carries volatile junk like
+    timestamps, review snippets, and PR URLs. When title alone feels too
+    coarse, pass a short stable prefix of the body (e.g. the task description
+    before any generated sections).
+    """
+    normalized = _normalize_title(title)
+    if body:
+        normalized += "|" + _normalize_title(body)[:200]
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+
+def is_duplicate_title(new_title: str, existing_titles: Iterable[str]) -> bool:
+    """True if ``new_title`` normalizes to the same string as any existing title."""
+    target = _normalize_title(new_title)
+    return any(_normalize_title(t) == target for t in existing_titles)

--- a/src/tools/github_tool.py
+++ b/src/tools/github_tool.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 
 try:
     from github import Github
@@ -9,6 +10,7 @@ except ImportError:
         def get_repo(self, name): return MockRepo()
     class MockRepo:
         def create_issue(self, title, body): return MockIssue()
+        def get_issues(self, state="open"): return []
         def get_branch(self, name):
             class MockBranch:
                 class MockCommit:
@@ -57,12 +59,59 @@ from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_ex
 
 from src.config import Config
 from src.observability.metrics import tool_timer
+from src.tools.content_guards import (
+    LEAKED_REVIEW_PLACEHOLDER,
+    is_low_value_content,
+    sanitize_review,
+)
+
+logger = logging.getLogger(__name__)
 
 _GITHUB_RETRY_WAIT = wait_exponential(multiplier=0.01, min=0, max=0.05)
+
+#: Cap for the open-issue scan used by create_issue dedup. Most repos stay well
+#: under 100 open issues; scanning more would slow every create_issue call and
+#: the marginal dedup value drops fast.
+_DEDUP_OPEN_ISSUE_SCAN_LIMIT = 100
+
+#: Token used in issue bodies to mark the critic review section. Keep in sync
+#: with the body template in autonomous_sdlc.py / android_rpg_sdlc.py.
+_CRITIC_REVIEW_MARKER = "**Critic Review:**"
+_REVIEW_MARKER = "**Review:**"
 
 
 class GitHubRetryableError(RuntimeError):
     """Raised for transient GitHub content reads that should be retried."""
+
+
+def _sanitize_review_section(body: str) -> str:
+    """Run sanitize_review over the content after a Critic Review / Review marker.
+
+    The SDLC pipelines build issue and PR bodies like::
+
+        **Critic Review:**
+        <raw agent output, possibly JSON leakage>
+
+    We walk the body, find the marker, sanitize everything after it up to the
+    next ``---`` separator (or end of body), and splice the clean version
+    back in. If no marker is found, the body is returned unchanged.
+    """
+    for marker in (_CRITIC_REVIEW_MARKER, _REVIEW_MARKER):
+        idx = body.find(marker)
+        if idx == -1:
+            continue
+        head = body[: idx + len(marker)]
+        tail = body[idx + len(marker) :]
+        # Review runs until a trailing separator (Feature Discovery footer etc.)
+        # or the end of the body.
+        sep_idx = tail.find("\n---")
+        if sep_idx == -1:
+            review_part, footer = tail, ""
+        else:
+            review_part, footer = tail[:sep_idx], tail[sep_idx:]
+        cleaned = sanitize_review(review_part)
+        return f"{head}\n{cleaned}{footer}"
+    return body
 
 
 class GitHubTool(Tool):
@@ -88,19 +137,77 @@ class GitHubTool(Tool):
         except Exception as exc:
             raise GitHubRetryableError(str(exc)) from exc
 
+    def _find_duplicate_open_issue(self, title: str):
+        """Return an existing open issue whose title matches ``title`` (case-insensitive,
+        whitespace-normalized), or None. Swallows errors — dedup is best-effort."""
+        from src.tools.content_guards import _normalize_title  # local to keep public API small
+        target = _normalize_title(title)
+        try:
+            # PyGithub's get_issues is paginated and lazy; slice to bound the scan.
+            for idx, issue in enumerate(self.repo.get_issues(state="open")):
+                if idx >= _DEDUP_OPEN_ISSUE_SCAN_LIMIT:
+                    break
+                # Skip pull requests — they show up in issues/ but we dedup those separately.
+                if getattr(issue, "pull_request", None):
+                    continue
+                if _normalize_title(issue.title) == target:
+                    return issue
+        except Exception as exc:  # pragma: no cover — observability only
+            logger.warning("dedup scan failed, filing anyway: %s", exc)
+        return None
+
     @tool_timer("GitHubTool")
     async def create_issue(self, title, body):
+        """Create an issue, with dedup against open issues + review-section sanitization.
+
+        If an open issue with the same title (normalized) already exists,
+        returns that issue's URL instead of filing a duplicate. The body is
+        scanned for a ``**Critic Review:**`` section and any tool-call-JSON
+        leakage in that section is replaced with a placeholder marker before
+        the issue is filed.
+        """
         if not self.repo:
             return "Error: Repository not configured or not found"
+
+        # Dedup: don't file a new issue if an equivalent open one exists.
+        existing = await asyncio.to_thread(self._find_duplicate_open_issue, title)
+        if existing is not None:
+            logger.info(
+                "create_issue: skipping duplicate of open issue #%s (%s)",
+                existing.number,
+                existing.html_url,
+            )
+            return existing.html_url
+
+        clean_body = _sanitize_review_section(body or "")
         try:
-            issue = self.repo.create_issue(title=title, body=body)
+            issue = self.repo.create_issue(title=title, body=clean_body)
             return issue.html_url
         except Exception as e:
             return f"Error creating issue: {str(e)}"
 
     async def create_pull_request(self, title: str, body: str, head: str, base: str = "main") -> str:
+        """Open a PR, with review-section sanitization and an empty-body guard.
+
+        Refuses to file the PR if the body (after sanitization) contains nothing
+        but the leaked-review placeholder — that's the signal that the Critic
+        produced no usable review and the pipeline should not have reached this
+        call. Pipelines are expected to check ``is_low_value_content`` on the
+        generated code before calling this, but we defend in depth here anyway.
+        """
         if not self.repo:
             return "Error: Repository not configured or not found"
+
+        clean_body = _sanitize_review_section(body or "")
+
+        # Defense in depth: if the only thing the body has to say is "the
+        # review was leakage", refuse to ship. Real PRs have task description
+        # text around the review section.
+        if is_low_value_content(clean_body.replace(LEAKED_REVIEW_PLACEHOLDER, ""), min_bytes=40):
+            msg = "Error creating PR: body is empty or contains only leaked review"
+            logger.warning("create_pull_request refused: %s (head=%s)", msg, head)
+            return msg
+
         try:
             # Ensure branch exists; if not, create it from base
             try:
@@ -108,7 +215,7 @@ class GitHubTool(Tool):
             except Exception:
                 default_branch = self.repo.get_branch(base)
                 self.repo.create_git_ref(ref=f"refs/heads/{head}", sha=default_branch.commit.sha)
-            pr = self.repo.create_pull(title=title, body=body, head=head, base=base)
+            pr = self.repo.create_pull(title=title, body=clean_body, head=head, base=base)
             return pr.html_url
         except Exception as e:
             return f"Error creating PR: {str(e)}"

--- a/tests/test_content_guards.py
+++ b/tests/test_content_guards.py
@@ -1,0 +1,189 @@
+"""
+Unit tests for src.tools.content_guards.
+
+Each test is named after the real failure mode it prevents from recurring.
+References are to issues/PRs in asshat1981ar/project-chimera.
+"""
+
+from src.tools.content_guards import (
+    LEAKED_REVIEW_PLACEHOLDER,
+    is_duplicate_title,
+    is_low_value_content,
+    issue_signature,
+    sanitize_review,
+)
+
+
+# ---------------------------------------------------------------------------
+# sanitize_review
+# ---------------------------------------------------------------------------
+
+
+def test_sanitize_review_passes_through_real_prose():
+    review = (
+        "1) What's good\n"
+        "- Clear separation of concerns.\n"
+        "- Type hints throughout.\n"
+        "\n2) What's missing\n"
+        "- No unit tests for the scanner logic.\n"
+    )
+    assert sanitize_review(review) == review.strip()
+
+
+def test_sanitize_review_rejects_raw_json_array_tool_call():
+    # Exact shape seen in project-chimera issues #167, #165, #151, #149, #145.
+    leakage = '[{"action": "list_repo_contents", "args": {"path": "src"}}]'
+    assert sanitize_review(leakage) == LEAKED_REVIEW_PLACEHOLDER
+
+
+def test_sanitize_review_rejects_raw_json_object_tool_call():
+    # Shape seen in #158, #141.
+    leakage = '{"action": "list_directory", "args": {"path": "src/test"}}'
+    assert sanitize_review(leakage) == LEAKED_REVIEW_PLACEHOLDER
+
+
+def test_sanitize_review_rejects_fenced_json_tool_call():
+    # Shape seen in #139, #136 — same leakage wrapped in a markdown fence.
+    leakage = '```json\n[{"action": "list_directory", "arguments": {"path": "src"}}]\n```'
+    assert sanitize_review(leakage) == LEAKED_REVIEW_PLACEHOLDER
+
+
+def test_sanitize_review_rejects_tool_name_key_variant():
+    # Some critic runs used "tool_name" instead of "action" — same failure class.
+    leakage = '[{"tool_name": "list_directory", "arguments": {"path": "src"}}]'
+    assert sanitize_review(leakage) == LEAKED_REVIEW_PLACEHOLDER
+
+
+def test_sanitize_review_rejects_thinking_fragment():
+    # Shape seen in PR #159 body: the RPG engine generated an empty Kotlin
+    # file and the "review" is the LLM thinking out loud.
+    leakage = (
+        "I'll review the Kotlin RPG Turn-Based Combat System component. "
+        "However, I notice the code snippet is empty. Let me first check "
+        "if there are any files in the repository that might contain this "
+        "component."
+    )
+    assert sanitize_review(leakage) == LEAKED_REVIEW_PLACEHOLDER
+
+
+def test_sanitize_review_rejects_sidestep():
+    # Shape seen in #147, #141: "Review saved to src/review.txt." — Critic
+    # wrote the review to the target repo instead of returning it. That
+    # leaked file write is itself a separate bug (tracked elsewhere), but
+    # the empty-return needs to be caught here too.
+    leakage = "Review completed and saved to src/review.txt."
+    assert sanitize_review(leakage) == LEAKED_REVIEW_PLACEHOLDER
+
+
+def test_sanitize_review_rejects_none_and_empty():
+    assert sanitize_review(None) == LEAKED_REVIEW_PLACEHOLDER
+    assert sanitize_review("") == LEAKED_REVIEW_PLACEHOLDER
+    assert sanitize_review("    \n   \n\t") == LEAKED_REVIEW_PLACEHOLDER
+
+
+def test_sanitize_review_keeps_prose_that_happens_to_contain_braces():
+    # We must not over-match — real review prose can reference JSON inline.
+    review = (
+        "The config struct looks correct. {foo: bar} style literals are "
+        "used consistently. No concerns."
+    )
+    assert sanitize_review(review) == review.strip()
+
+
+# ---------------------------------------------------------------------------
+# is_low_value_content
+# ---------------------------------------------------------------------------
+
+
+def test_is_low_value_content_rejects_empty_and_none():
+    assert is_low_value_content(None) is True
+    assert is_low_value_content("") is True
+    assert is_low_value_content("   \n\n  ") is True
+
+
+def test_is_low_value_content_rejects_kotlin_class_stub():
+    # The shape of real stubs the RPG engine has been shipping.
+    stub = "class TurnBasedCombatSystem {\n}\n"
+    assert is_low_value_content(stub) is True
+
+
+def test_is_low_value_content_rejects_python_pass_stub():
+    stub = "class Foo:\n    pass\n"
+    assert is_low_value_content(stub) is True
+
+
+def test_is_low_value_content_rejects_comment_only():
+    stub = "// TODO: implement\n// will do later\n"
+    assert is_low_value_content(stub) is True
+
+
+def test_is_low_value_content_accepts_real_implementation():
+    # Long enough to clear the 80-byte floor and not a stub pattern.
+    real = (
+        "class CombatManager {\n"
+        "  fun attack(target: Actor, weapon: Weapon): DamageResult {\n"
+        "    val hitRoll = dice.roll(20) + weapon.toHit\n"
+        "    if (hitRoll >= target.armorClass) {\n"
+        "      return DamageResult.hit(weapon.damage.roll())\n"
+        "    }\n"
+        "    return DamageResult.miss()\n"
+        "  }\n"
+        "}\n"
+    )
+    assert is_low_value_content(real) is False
+
+
+def test_is_low_value_content_respects_custom_min_bytes():
+    # Explicit override for callers who want stricter/looser gates.
+    short_but_real = "val x = computeCriticalHitMultiplier(actor, weapon)"
+    assert is_low_value_content(short_but_real, min_bytes=100) is True
+    assert is_low_value_content(short_but_real, min_bytes=10) is False
+
+
+# ---------------------------------------------------------------------------
+# issue_signature / is_duplicate_title
+# ---------------------------------------------------------------------------
+
+
+def test_issue_signature_is_stable():
+    sig1 = issue_signature("[SWARM TASK] Implement Property-Based Testing")
+    sig2 = issue_signature("[SWARM TASK] Implement Property-Based Testing")
+    assert sig1 == sig2
+
+
+def test_issue_signature_ignores_trivial_whitespace_drift():
+    # Same title with extra spaces must normalize identically.
+    sig1 = issue_signature("[SWARM TASK] Implement Property-Based Testing")
+    sig2 = issue_signature("[SWARM TASK]   Implement  Property-Based Testing  ")
+    assert sig1 == sig2
+
+
+def test_issue_signature_distinguishes_different_titles():
+    sig1 = issue_signature("[SWARM TASK] Implement Property-Based Testing")
+    sig2 = issue_signature("[SWARM TASK] Implement Fuzz Testing")
+    assert sig1 != sig2
+
+
+def test_is_duplicate_title_catches_the_real_127_to_133_case():
+    # The 7 duplicates in project-chimera #127-#133 all had this exact title.
+    new = "[SWARM TASK] Implement Property-Based Testing"
+    existing = [
+        "[SWARM TASK] Implement Property-Based Testing",  # #127
+        "[SDLCBot] Add unit test suite with JUnit5 and MockK",
+    ]
+    assert is_duplicate_title(new, existing) is True
+
+
+def test_is_duplicate_title_is_case_insensitive():
+    new = "[SWARM TASK] Implement Property-Based Testing"
+    existing = ["[swarm task] implement property-based testing"]
+    assert is_duplicate_title(new, existing) is True
+
+
+def test_is_duplicate_title_no_false_positive():
+    new = "[SDLCBot] Add Room database layer"
+    existing = [
+        "[SDLCBot] Add Jetpack Navigation component",
+        "[SDLCBot] Add dependency injection with Koin",
+    ]
+    assert is_duplicate_title(new, existing) is False


### PR DESCRIPTION
## Summary
- add content guards to suppress leaked Critic tool-call JSON before it reaches PR bodies or tracking issues
- reject low-value or empty generated artifacts before opening delivery PRs
- deduplicate swarm-created issues to avoid repeated task spam

## Tests
- python3 -m pytest tests/test_content_guards.py -v