### PR TITLE
PR #13 follow-up: address remaining review feedback, fix stale tests, raise coverage floor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,10 +65,12 @@ jobs:
       - run: pip install coverage[toml] pytest pytest-asyncio
       - run: coverage run -m pytest -q
       - run: coverage xml
-      # Soft coverage floor: keep it low to unblock CI while we add agent
-      # and CLI tests incrementally. Raised as the phase-gate milestones
-      # land (see plan: Phase 5 targets 65% global, 80% changed-files).
-      - run: coverage report --fail-under=35
+      # Coverage floor. Raised from 35% once the stable test subset
+      # consistently measured 52%+ on the swarm's core modules. Plan's
+      # long-term target is 65% global / 80% changed-files (Phase 5);
+      # bumping here incrementally rather than in one jump so a missing
+      # test file fails fast without trapping contributors at 0 headroom.
+      - run: coverage report --fail-under=45
       - uses: actions/upload-artifact@v4
         if: matrix.python-version == '3.11'
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
         with:
           python-version: "3.11"
           cache: pip
+      # Ruff version kept in sync with `pyproject.toml` [dev] extra and
+      # `.pre-commit-config.yaml` to prevent formatter-output drift
+      # between CI and local development.
       - run: pip install ruff==0.5.7
       - run: ruff check src tests
       - run: ruff format --check src tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,12 @@ license = { text = "Proprietary" }
 
 [project.optional-dependencies]
 dev = [
-    "ruff>=0.5",
+    # Pin ruff to the CI version so `ruff format` output matches between
+    # local and CI. A loose `>=0.5` will otherwise pick up whatever
+    # minor/major is current, whose formatter can disagree with the
+    # CI-pinned version and produce spurious lint-gate failures.
+    # Keep this in sync with `.github/workflows/ci.yml`.
+    "ruff==0.5.7",
     "mypy>=1.10",
     "pip-audit>=2.7",
     "bandit>=1.7",

--- a/src/cli/swarm_ctl.py
+++ b/src/cli/swarm_ctl.py
@@ -8,11 +8,44 @@ Provides inter-process communication via sentinel files and queues:
 
 import json
 import os
+from contextlib import contextmanager
 from datetime import UTC, datetime
+
+try:
+    import fcntl as _fcntl
+
+    _QUEUE_FLOCK_AVAILABLE = True
+except ImportError:  # Windows — best-effort without locking
+    _fcntl = None  # type: ignore[assignment]
+    _QUEUE_FLOCK_AVAILABLE = False
 
 SENTINEL_PATH = ".swarm_shutdown"
 QUEUE_PATH = "prompt_queue.jsonl"
 PID_PATH = "swarm.pid"
+
+
+@contextmanager
+def _queue_lock(mode: str):
+    """Open ``QUEUE_PATH`` in ``mode`` holding an exclusive ``fcntl`` lock.
+
+    All ``prompt_queue.jsonl`` accessors (enqueue + dequeue + peek) route
+    through this so the self-prompt background thread's appends cannot
+    race with the main loop's read-then-unlink in ``dequeue_prompts``.
+    """
+    f = open(QUEUE_PATH, mode)
+    try:
+        if _QUEUE_FLOCK_AVAILABLE:
+            _fcntl.flock(f, _fcntl.LOCK_EX)
+        try:
+            yield f
+            if "w" in mode or "a" in mode:
+                f.flush()
+                os.fsync(f.fileno())
+        finally:
+            if _QUEUE_FLOCK_AVAILABLE:
+                _fcntl.flock(f, _fcntl.LOCK_UN)
+    finally:
+        f.close()
 
 
 def is_shutdown_requested() -> bool:
@@ -55,37 +88,53 @@ def enqueue_prompt(prompt: str, user_id: str = "cli_user") -> None:
         "user_id": user_id,
         "prompt": prompt,
     }
-    with open(QUEUE_PATH, "a") as f:
+    with _queue_lock("a") as f:
         f.write(json.dumps(entry) + "\n")
 
 
 def dequeue_prompts() -> list[dict]:
+    """Read all queued prompts and clear the file in one locked operation.
+
+    Must hold the queue lock across read + ``os.remove`` so a concurrent
+    enqueue (from the self-prompt background thread) can't land in a
+    file we're about to unlink and silently lose the prompt.
+    """
     if not os.path.exists(QUEUE_PATH):
         return []
-    entries = []
-    with open(QUEUE_PATH) as f:
-        for line in f:
-            line = line.strip()
-            if line:
-                try:
-                    entries.append(json.loads(line))
-                except json.JSONDecodeError:
-                    continue
-    # Clear queue after reading
-    os.remove(QUEUE_PATH)
+    entries: list[dict] = []
+    try:
+        with _queue_lock("r") as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    try:
+                        entries.append(json.loads(line))
+                    except json.JSONDecodeError:
+                        continue
+            # Still under the exclusive lock — any blocked enqueuer waits
+            # and opens a fresh file once we release.
+            try:
+                os.remove(QUEUE_PATH)
+            except FileNotFoundError:
+                pass
+    except FileNotFoundError:
+        return []
     return entries
 
 
 def peek_prompts() -> list[dict]:
     if not os.path.exists(QUEUE_PATH):
         return []
-    entries = []
-    with open(QUEUE_PATH) as f:
-        for line in f:
-            line = line.strip()
-            if line:
-                try:
-                    entries.append(json.loads(line))
-                except json.JSONDecodeError:
-                    continue
+    entries: list[dict] = []
+    try:
+        with _queue_lock("r") as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    try:
+                        entries.append(json.loads(line))
+                    except json.JSONDecodeError:
+                        continue
+    except FileNotFoundError:
+        return []
     return entries

--- a/src/services/embedder.py
+++ b/src/services/embedder.py
@@ -59,7 +59,8 @@ class LiteLLMEmbedder:
             )
         self._model = model or Config.EMBED_MODEL
         if quota is None:
-            quota = EmbedQuota(state_manager)  # type: ignore[arg-type]
+            assert state_manager is not None  # guaranteed by the guard above
+            quota = EmbedQuota(state_manager)
         self._quota = quota
 
     @property
@@ -123,19 +124,27 @@ def build_default_embedder(
 ) -> LiteLLMEmbedder | None:
     """Construct the default embedder used by :mod:`retrieval_context`.
 
-    ``state_manager`` is **required in practice** — pass in the same
-    ``StateManager`` instance the swarm uses elsewhere so quota writes
-    don't race with task-state writes. Callers that don't have one
-    already can construct ``StateManager()`` once at bootstrap and
-    thread it through.
+    ``state_manager`` is **required**. If omitted this returns ``None``
+    (the caller then falls back to keyword retrieval with a
+    ``retrieval.degraded`` log). This is intentional: auto-constructing
+    a fresh ``StateManager()`` would create a second writer of
+    ``state.json`` that races with the swarm's shared instance and can
+    clobber task state under concurrent writes.
+
+    Wiring guidance: the swarm entrypoint (``src.main``) builds a
+    ``StateManager`` once at startup and threads it through to both the
+    self-prompt tick and, via ``set_embedder``, into any vector-path
+    retrieval. Tests that exercise the vector path supply their own
+    ``state_manager`` to keep isolation tight.
 
     Returns ``None`` when:
     - ``Config.TEST_MODE`` is on (keep tests hermetic unless they opt in
       via their own embedder fixture);
     - ``Config.OPENROUTER_API_KEY`` is missing (fail fast via the
       keyword-fallback path instead of surfacing auth errors);
-    - or the current ``Config.RETRIEVAL_BACKEND`` is not a vector name
-      (don't pay the setup cost if we'll never be used).
+    - ``Config.RETRIEVAL_BACKEND`` is not a vector name (don't pay the
+      setup cost if we'll never be used);
+    - or ``state_manager`` is not supplied (safety rail described above).
     """
     if Config.TEST_MODE:
         return None
@@ -145,11 +154,14 @@ def build_default_embedder(
     backend = (Config.RETRIEVAL_BACKEND or "").strip().lower()
     if backend not in {"vector", "sqlite-vec", "sqlitevec"}:
         return None
-    # Fall back to a fresh StateManager only when the caller didn't pass
-    # one — LiteLLMEmbedder enforces that *something* is supplied, so we
-    # surface a construction error rather than silently spawning a racing
-    # writer.
-    return LiteLLMEmbedder(state_manager=state_manager or StateManager())
+    if state_manager is None:
+        logger.warning(
+            "build_default_embedder: no state_manager supplied; refusing "
+            "to auto-construct one. Pass the swarm's shared StateManager "
+            "to enable vector retrieval — falling back to keyword until then."
+        )
+        return None
+    return LiteLLMEmbedder(state_manager=state_manager)
 
 
 __all__ = ["LiteLLMEmbedder", "build_default_embedder"]

--- a/src/services/retrieval_context.py
+++ b/src/services/retrieval_context.py
@@ -190,7 +190,17 @@ def _sync_corpus_to_backend(
     - Upserts only docs whose SHA-256 content hash changed.
     - Removes docs that were previously indexed but are no longer on disk.
     - Returns the number of documents currently present after sync.
+
+    The hash cache is only written for backends that actually persist
+    writes. Without that guard, a degraded run backed by ``NullVectorIndex``
+    would mark every file as "current" and cause later retrievals against
+    a real backend to skip them forever, leaving the index empty.
     """
+    # Skip hash caching when the backend is the no-op placeholder — its
+    # upsert() doesn't persist anything, so subsequent runs must still see
+    # the files as "changed" and re-embed them into a real backend.
+    backend_persists = getattr(backend, "name", "") != "null"
+
     seen_ids: set[str] = set()
     for corpus_name, path in _collect_corpus_files(resolved_root, corpus):
         try:
@@ -203,7 +213,7 @@ def _sync_corpus_to_backend(
         doc_id = str(path.relative_to(resolved_root))
         seen_ids.add(doc_id)
         sha = _sha(text)
-        if _doc_hashes.get(doc_id) == sha:
+        if backend_persists and _doc_hashes.get(doc_id) == sha:
             # Unchanged since last call — skip the (costly) embed.
             continue
         backend.upsert(
@@ -211,14 +221,25 @@ def _sync_corpus_to_backend(
             text=text,
             metadata={"corpus": corpus_name, "path": doc_id},
         )
-        _doc_hashes[doc_id] = sha
+        if backend_persists:
+            _doc_hashes[doc_id] = sha
 
     # Drop backend rows + cache entries whose source file disappeared so
     # stale embeddings don't get served in future queries. Only supported
     # on backends that expose `known_doc_ids` / `delete` (SqliteVecBackend);
-    # the NullVectorIndex no-ops both.
+    # the NullVectorIndex no-ops both. IMPORTANT: scope the cleanup to the
+    # corpora we actually synced this call — without that restriction,
+    # retrieving only `specs` would wipe all `plans` / `history` docs from
+    # the shared index.
     if hasattr(backend, "known_doc_ids") and hasattr(backend, "delete"):
-        for stale_id in backend.known_doc_ids() - seen_ids:
+        try:
+            in_scope = backend.known_doc_ids(corpora=corpus)
+        except TypeError:
+            # Older backend without the corpus filter — fall back to
+            # full scan (matches pre-fix behavior). This path is
+            # intentionally conservative.
+            in_scope = backend.known_doc_ids()
+        for stale_id in in_scope - seen_ids:
             backend.delete(stale_id)
             _doc_hashes.pop(stale_id, None)
 

--- a/src/services/self_prompt.py
+++ b/src/services/self_prompt.py
@@ -244,6 +244,18 @@ def dispatch(
     usage — multi-writer access is out of scope for Phase 4.
     """
     accepted: list[SelfPrompt] = []
+    # Optional fcntl lock — matches the swarm_ctl queue accessors so the
+    # background self-prompt thread can't race with the main loop's
+    # dequeue read-then-unlink. Best-effort: if fcntl isn't available
+    # (Windows) we fall through to a plain append.
+    try:
+        import fcntl as _fcntl_mod
+
+        _have_flock = True
+    except ImportError:  # pragma: no cover — platform-dependent
+        _fcntl_mod = None  # type: ignore[assignment]
+        _have_flock = False
+
     for prompt in prompts:
         if not rate_limiter.try_consume():
             logger.info(
@@ -257,7 +269,15 @@ def dispatch(
             "self_prompt": prompt.model_dump(mode="json"),
         }
         with open(queue_path, "a") as f:
-            f.write(json.dumps(entry) + "\n")
+            if _have_flock:
+                _fcntl_mod.flock(f, _fcntl_mod.LOCK_EX)
+            try:
+                f.write(json.dumps(entry) + "\n")
+                f.flush()
+                os.fsync(f.fileno())
+            finally:
+                if _have_flock:
+                    _fcntl_mod.flock(f, _fcntl_mod.LOCK_UN)
         accepted.append(prompt)
     return accepted
 

--- a/src/services/vector_index.py
+++ b/src/services/vector_index.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
@@ -241,10 +241,29 @@ class SqliteVecBackend:
             self._conn.execute(f"DELETE FROM {self._INDEX_TABLE} WHERE rowid = ?", (rowid,))
             self._conn.execute(f"DELETE FROM {self._META_TABLE} WHERE rowid = ?", (rowid,))
 
-    def known_doc_ids(self) -> set[str]:
-        """Return every ``doc_id`` currently indexed."""
-        rows = self._conn.execute(f"SELECT doc_id FROM {self._META_TABLE}").fetchall()
-        return {row[0] for row in rows}
+    def known_doc_ids(self, *, corpora: Iterable[str] | None = None) -> set[str]:
+        """Return every ``doc_id`` currently indexed.
+
+        When ``corpora`` is provided, returns only docs whose stored
+        metadata ``corpus`` key is in that iterable. Used by the
+        retrieval-context sync loop to scope stale-doc cleanup so it
+        never touches docs belonging to corpora that weren't part of
+        the current request.
+        """
+        rows = self._conn.execute(f"SELECT doc_id, metadata FROM {self._META_TABLE}").fetchall()
+        if corpora is None:
+            return {row[0] for row in rows}
+        wanted = {c.strip().lower() for c in corpora}
+        ids: set[str] = set()
+        for doc_id, raw in rows:
+            try:
+                meta = json.loads(raw or "{}")
+            except (TypeError, ValueError):
+                continue
+            corpus = str(meta.get("corpus", "")).strip().lower()
+            if corpus in wanted:
+                ids.add(doc_id)
+        return ids
 
     def query(self, text: str, top_k: int = 3) -> list[SearchHit]:
         if top_k <= 0:

--- a/src/state.py
+++ b/src/state.py
@@ -14,8 +14,11 @@ except ImportError:  # Windows
 
 _logger = logging.getLogger(__name__)
 
-if not _FLOCK_AVAILABLE:
-    _logger.warning("fcntl unavailable on this platform; concurrent appends will not be serialized")
+#: One-shot guard so the "fcntl unavailable" warning fires at most once
+#: per process (on the first actual append) rather than at import time —
+#: avoids log noise before logging is configured and ensures the warning
+#: respects the runtime log level chosen by the caller.
+_FLOCK_WARNED = False
 
 
 class StateManager:
@@ -57,14 +60,34 @@ class StateManager:
         """Append *line* (already serialised) to *path* with an advisory lock.
 
         On platforms where ``fcntl`` is unavailable (Windows) the lock is
-        skipped and a warning is emitted, but the append is still performed so
-        the module remains functional.
+        skipped and a one-shot warning is emitted (at first call, not at
+        import), but the append is still performed so the module stays
+        functional.
+
+        Important: we ``flush()`` and ``fsync()`` *before* releasing the
+        ``fcntl`` lock. Without that, Python's text buffer could still
+        hold the data while another process acquired the lock, letting
+        lines interleave in the final file.
         """
+        global _FLOCK_WARNED
+        if not _FLOCK_AVAILABLE and not _FLOCK_WARNED:
+            _logger.warning(
+                "fcntl unavailable on this platform; concurrent appends "
+                "to %s will not be serialized",
+                path,
+            )
+            _FLOCK_WARNED = True
+
         with open(path, "a") as f:
             if _FLOCK_AVAILABLE:
                 _fcntl.flock(f, _fcntl.LOCK_EX)
                 try:
                     f.write(line + "\n")
+                    # Flush+fsync inside the critical section so the
+                    # bytes are on disk before the next process's
+                    # lock_ex grant can race against our buffer.
+                    f.flush()
+                    os.fsync(f.fileno())
                 finally:
                     _fcntl.flock(f, _fcntl.LOCK_UN)
             else:

--- a/tests/services/test_retrieval_backend_routing.py
+++ b/tests/services/test_retrieval_backend_routing.py
@@ -271,9 +271,9 @@ def test_vector_retrieve_skips_reembedding_unchanged_docs(
 
         # Second call with identical files: no new upserts.
         rc.retrieve_context(RetrievalQuery(query="alpha"), repo_root=tmp_path)
-        assert _SpyBackend.upsert_count == first_upserts, (
-            "unchanged docs must not trigger re-embedding"
-        )
+        assert (
+            _SpyBackend.upsert_count == first_upserts
+        ), "unchanged docs must not trigger re-embedding"
 
         # Modify one file: only that one re-upserts.
         (tmp_path / "docs" / "superpowers" / "specs" / "a.md").write_text("alpha beta gamma NEW")

--- a/tests/services/test_sqlite_vec_backend.py
+++ b/tests/services/test_sqlite_vec_backend.py
@@ -180,9 +180,9 @@ def test_recall_at_k_on_small_corpus(backend: SqliteVecBackend) -> None:
 
     hits = backend.query("vector embedding retrieval", top_k=5)
     assert hits
-    assert hits[0].doc_id == "memory", (
-        f"expected memory to rank first, got {[h.doc_id for h in hits]}"
-    )
+    assert (
+        hits[0].doc_id == "memory"
+    ), f"expected memory to rank first, got {[h.doc_id for h in hits]}"
 
 
 def test_hit_metadata_exposes_distance(backend: SqliteVecBackend) -> None:

--- a/tests/test_config_settings.py
+++ b/tests/test_config_settings.py
@@ -17,7 +17,13 @@ def test_settings_reads_defaults_without_env(monkeypatch):
 
     assert settings.openrouter_model == "openrouter/elephant-alpha"
     assert settings.llm_timeout == 30
-    assert settings.fallback_models[0] == "openai/gpt-4o"
+    # _default_fallback_models prefixes the chain with ``openrouter/`` so
+    # LiteLLM routes through the OpenRouter-compatible endpoint rather
+    # than the provider-native one (which would 404 on /chat/completions).
+    assert settings.fallback_models[0] == "openrouter/openai/gpt-4o"
+    # And every entry must carry the prefix — any unprefixed entry means
+    # the defensive fix in `_default_fallback_models` regressed.
+    assert all(model.startswith("openrouter/") for model in settings.fallback_models)
 
 
 def test_settings_parses_boolean_flags(monkeypatch):

--- a/tests/test_pr_automation.py
+++ b/tests/test_pr_automation.py
@@ -33,7 +33,12 @@ def test_read_repo_file_retries_transient_content_errors(monkeypatch):
         def get_contents(self, path, ref=None):
             self.calls += 1
             if self.calls == 1:
-                raise RuntimeError("temporary github error")
+                # Must be a member of `_GITHUB_API_ERRORS` so the narrow
+                # catch in `_get_contents_with_retry` wraps it into
+                # `GitHubRetryableError` for tenacity. A plain
+                # `RuntimeError` would no longer qualify (it's a real
+                # bug, not a transient API hiccup).
+                raise ConnectionError("temporary github error")
             return FakeContent()
 
     gh = GitHubTool()


### PR DESCRIPTION
Follow-up hygiene pass on top of PR #13. Three commits on the same branch:

- `8b49d87` — addresses the remaining PR #13 review feedback that landed after the PR merged.
- `34cba4d` — fixes two pre-existing stale tests and aligns the ruff pin across CI, dev, and pre-commit so the local/CI formatter drift that surfaced on PR #13 can't recur.
- `814b11b` — raises the CI coverage floor from 35% → 45%.

## What's fixed

### `8b49d87` — Review-feedback from PR #13 (Gemini + Copilot + Codex)

| Source | Severity | Fix |
|---|---|---|
| Gemini | critical | `_sync_corpus_to_backend` no longer wipes other corpora's docs. Cleanup scoped via new `SqliteVecBackend.known_doc_ids(corpora=...)` filter so retrieving `specs` can't vaporize `plans`. |
| Codex | P2 | `_doc_hashes` skipped when backend is `NullVectorIndex`. Prevents a degraded run from "marking" every file as current and starving a later real-backend run. |
| Gemini + Copilot | medium | `build_default_embedder` refuses to auto-construct a `StateManager`; returns `None` with a warning instead of creating a second writer that races with task state. |
| Copilot | — | `# type: ignore[arg-type]` replaced with `assert state_manager is not None` to preserve type-checking signal. |
| Copilot | — | `state.py` `fcntl`-unavailable warning moved from module-import scope to lazy one-shot — respects runtime log config. |
| Copilot (suppressed, correctness) | high | `_append_locked` now `flush()`+`fsync()` *inside* the lock. Without this, Python's text buffer could hold data past `LOCK_UN`, letting JSONL lines interleave. |
| Codex | P1 | `_queue_lock()` helper serializes all `prompt_queue.jsonl` access (enqueue/dequeue/peek + `self_prompt.dispatch`). Resolves the race between the self-prompt background thread's appends and the main loop's read-then-unlink. |

### `34cba4d` — Stale-test + tooling alignment

- `test_config_settings.py::test_settings_reads_defaults_without_env` expected the pre-Phase-0 `openai/gpt-4o` fallback; updated to the `openrouter/` prefix and added an invariant that every fallback model carries it.
- `test_pr_automation.py::test_read_repo_file_retries_transient_content_errors` simulated a transient error with `RuntimeError`, but Phase 0 narrowed the catch to `_GITHUB_API_ERRORS`. Switched the simulated error to `ConnectionError`.
- `pyproject.toml [dev]` pinned `ruff==0.5.7` to match `.github/workflows/ci.yml` and `.pre-commit-config.yaml` (previously `ruff>=0.5` let local dev pick up 0.15.8 whose formatter disagreed with CI).

### `814b11b` — CI coverage floor 35% → 45%

- Stable test subset measures 52% locally across 276 passing tests.
- Core modules (`phase_controller`, `quality_gates`, `embed_quota`, `embedder`, `self_prompt`, `vector_index`, `phase_store`, `sdlc_phase`, `SqliteVecBackend`) all sit at 83%+ individually.
- New floor keeps contributors at ~7 points of headroom while making a missing-test regression on a non-trivial module impossible.

## Tests

- **276 local tests green** on the stable subset (ups 269→276 because the two stale files now run).
- `ruff check src tests` — clean under the CI-pinned 0.5.7.
- `ruff format --check src tests` — clean.
- `coverage report --fail-under=45` — passes at 52%.

## Checks

- [x] `pytest -q` — 276 green (stable subset)
- [x] Lint + format clean (pinned ruff)
- [x] `coverage report --fail-under=45` passes
- [ ] CI run on this PR (lint / typecheck / test / security / coverage)

No behavior change on the keyword-retrieval default. Every fix targets a failure mode either the vector path, the self-prompt loop, or CI would otherwise hit.

https://claude.ai/code/session_01665TpXDGRoB8ipxn8n3on5