### PR TITLE
Stop litellm.embedding from blocking the swarm event loop (async handler + aembed)

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -39,9 +39,22 @@ register_tool("list_repo_contents", list_repo_contents)
 register_tool("retrieve_planning_context", retrieve_planning_context)
 
 
-def _planning_retrieval_handler(request: CapabilityRequest) -> dict[str, object]:
+async def _planning_retrieval_handler(request: CapabilityRequest) -> dict[str, object]:
+    """Async capability handler for `planning.retrieve_context`.
+
+    `retrieve_context` is synchronous and, in vector mode, blocks on
+    `litellm.embedding` for seconds per query. Dispatch it through
+    `asyncio.to_thread` so the swarm event loop stays responsive —
+    `_self_prompt_tick`, the dequeue loop, and other async agent tools
+    continue making progress while the embedding call is in flight.
+
+    `CapabilityService._execute_passthrough_capability` checks
+    `inspect.isawaitable(output)` and awaits when the handler returns
+    a coroutine, so this change is invisible to the capability
+    plumbing.
+    """
     query = RetrievalQuery.model_validate(request.arguments)
-    return retrieve_context(query)
+    return await asyncio.to_thread(retrieve_context, query)
 
 
 _register_capability(

--- a/src/services/embedder.py
+++ b/src/services/embedder.py
@@ -67,34 +67,35 @@ class LiteLLMEmbedder:
     def model(self) -> str:
         return self._model
 
-    def __call__(self, texts: Sequence[str]) -> list[list[float]]:
-        texts = list(texts or [])
-        if not texts:
-            return []
+    # -- shared sync/async flow helpers ---------------------------------
 
-        # Pre-call quota check on the rough estimate. If this trips, we
-        # raise before spending any LiteLLM-side tokens; the actual
-        # consumption from the response supersedes the estimate below.
+    def _precheck(self, texts: list[str]) -> int:
+        """Validate + reserve token budget. Returns the pre-call estimate."""
         pre_estimate = estimate_tokens(texts)
         try:
             self._quota.check(pre_estimate)
         except EmbedQuotaExceeded as exc:
             raise VectorBackendUnavailable(f"embed quota exceeded: {exc}") from exc
+        return pre_estimate
 
+    def _import_litellm(self):
         try:
             import litellm  # local import: heavy dep, env-dependent
         except ImportError as exc:  # pragma: no cover — depends on env
             raise VectorBackendUnavailable(
                 f"litellm not installed; cannot produce embeddings: {exc}"
             ) from exc
+        return litellm
 
-        try:
-            response = litellm.embedding(model=self._model, input=texts)
-        except Exception as exc:  # noqa: BLE001 — external SDK surface
-            logger.error("litellm.embedding failed: %s", exc, exc_info=True)
-            raise VectorBackendUnavailable(f"embedding call failed: {exc}") from exc
+    def _parse_and_record(self, response, pre_estimate: int) -> list[list[float]]:
+        """Extract vectors from the LiteLLM response envelope and update
+        the quota with actual usage (falling back to the pre-call estimate
+        if the provider didn't surface a usage block).
 
-        # Extract vectors. LiteLLM normalizes to OpenAI-shape:
+        Shared by both ``__call__`` and ``aembed`` so the two paths can't
+        drift on response-shape handling or token accounting.
+        """
+        # LiteLLM normalizes to OpenAI-shape:
         # {"data": [{"embedding": [...]}, ...], "usage": {...}}
         try:
             data = response["data"]  # type: ignore[index]
@@ -116,6 +117,56 @@ class LiteLLMEmbedder:
             pass
         self._quota.record(used)
         return vectors
+
+    # -- public sync + async entrypoints --------------------------------
+
+    def __call__(self, texts: Sequence[str]) -> list[list[float]]:
+        """Synchronous embed — canonical Embedder-protocol entrypoint.
+
+        Blocks the caller until the LiteLLM call returns. If you're in an
+        async context and can't afford to block the event loop, prefer
+        :meth:`aembed` (native async via ``litellm.aembedding``) or wrap
+        this call with ``asyncio.to_thread`` at the caller.
+        """
+        texts = list(texts or [])
+        if not texts:
+            return []
+
+        pre_estimate = self._precheck(texts)
+        litellm = self._import_litellm()
+
+        try:
+            response = litellm.embedding(model=self._model, input=texts)
+        except Exception as exc:  # noqa: BLE001 — external SDK surface
+            logger.error("litellm.embedding failed: %s", exc, exc_info=True)
+            raise VectorBackendUnavailable(f"embedding call failed: {exc}") from exc
+
+        return self._parse_and_record(response, pre_estimate)
+
+    async def aembed(self, texts: Sequence[str]) -> list[list[float]]:
+        """Native async embed via ``litellm.aembedding``.
+
+        Same quota accounting and failure semantics as :meth:`__call__`
+        — the difference is this one doesn't block the event loop while
+        the HTTP round-trip is in flight. Intended for future callers
+        that run inside an async handler and want to avoid the
+        ``asyncio.to_thread`` hop; Phase 3c currently routes through
+        the thread-pool wrapper in ``_planning_retrieval_handler``.
+        """
+        texts = list(texts or [])
+        if not texts:
+            return []
+
+        pre_estimate = self._precheck(texts)
+        litellm = self._import_litellm()
+
+        try:
+            response = await litellm.aembedding(model=self._model, input=texts)
+        except Exception as exc:  # noqa: BLE001 — external SDK surface
+            logger.error("litellm.aembedding failed: %s", exc, exc_info=True)
+            raise VectorBackendUnavailable(f"embedding call failed: {exc}") from exc
+
+        return self._parse_and_record(response, pre_estimate)
 
 
 def build_default_embedder(

--- a/tests/services/test_embedder.py
+++ b/tests/services/test_embedder.py
@@ -32,25 +32,35 @@ def _install_fake_litellm(
     raise_on_call: Exception | None = None,
     malformed: bool = False,
 ) -> list[dict]:
-    """Install a fake ``litellm`` module; return a list that captures calls."""
+    """Install a fake ``litellm`` module; return a list that captures calls.
+
+    Stubs both ``embedding`` (sync) and ``aembedding`` (async) so the
+    same fake works for both ``__call__`` and ``aembed`` tests.
+    """
     calls: list[dict] = []
 
-    def _embedding(*, model: str, input: list[str]):  # noqa: A002 — match SDK
-        calls.append({"model": model, "input": list(input)})
+    def _build_payload(model: str, input_: list[str]):
         if raise_on_call is not None:
             raise raise_on_call
         if malformed:
             return {"unexpected": "shape"}
-        vecs = vectors if vectors is not None else [[0.1, 0.2, 0.3] for _ in input]
-        payload = {
-            "data": [{"embedding": v} for v in vecs],
-        }
+        vecs = vectors if vectors is not None else [[0.1, 0.2, 0.3] for _ in input_]
+        payload: dict = {"data": [{"embedding": v} for v in vecs]}
         if total_tokens is not None:
             payload["usage"] = {"total_tokens": total_tokens}
         return payload
 
+    def _embedding(*, model: str, input: list[str]):  # noqa: A002 — match SDK
+        calls.append({"mode": "sync", "model": model, "input": list(input)})
+        return _build_payload(model, list(input))
+
+    async def _aembedding(*, model: str, input: list[str]):  # noqa: A002
+        calls.append({"mode": "async", "model": model, "input": list(input)})
+        return _build_payload(model, list(input))
+
     fake = types.ModuleType("litellm")
     fake.embedding = _embedding  # type: ignore[attr-defined]
+    fake.aembedding = _aembedding  # type: ignore[attr-defined]
     monkeypatch.setitem(sys.modules, "litellm", fake)
     return calls
 
@@ -170,3 +180,102 @@ def test_build_default_embedder_builds_when_conditions_met(
     built = build_default_embedder(state_manager=sm)
     assert isinstance(built, LiteLLMEmbedder)
     assert built.model == "openrouter/openai/text-embedding-3-small"
+
+
+# ---------------------------------------------------------------------------
+# Async embed path — mirrors the sync tests against ``LiteLLMEmbedder.aembed``.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_aembed_returns_vectors_and_records_tokens(
+    sm: StateManager, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls = _install_fake_litellm(
+        monkeypatch,
+        vectors=[[1.0, 0.0], [0.0, 1.0]],
+        total_tokens=42,
+    )
+    quota = EmbedQuota(sm, daily_cap=1000)
+    embedder = LiteLLMEmbedder(model="test/model", quota=quota)
+
+    out = await embedder.aembed(["hello", "world"])
+
+    assert out == [[1.0, 0.0], [0.0, 1.0]]
+    assert len(calls) == 1
+    assert calls[0]["mode"] == "async"
+    assert calls[0]["model"] == "test/model"
+    assert calls[0]["input"] == ["hello", "world"]
+    assert quota.used_today() == 42
+
+
+@pytest.mark.asyncio
+async def test_aembed_falls_back_to_estimate_without_usage(
+    sm: StateManager, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _install_fake_litellm(monkeypatch, vectors=[[0.1, 0.2]])
+    quota = EmbedQuota(sm, daily_cap=1000)
+    embedder = LiteLLMEmbedder(model="m", quota=quota)
+    await embedder.aembed(["abcd" * 8])  # 32 chars → estimate 8 tokens
+    assert quota.used_today() == 8
+
+
+@pytest.mark.asyncio
+async def test_aembed_empty_batch_short_circuits(
+    sm: StateManager, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls = _install_fake_litellm(monkeypatch)
+    embedder = LiteLLMEmbedder(model="m", quota=EmbedQuota(sm, daily_cap=10))
+    assert await embedder.aembed([]) == []
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_aembed_quota_check_rejects_before_calling_litellm(
+    sm: StateManager, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls = _install_fake_litellm(monkeypatch)
+    quota = EmbedQuota(sm, daily_cap=5)
+    quota.record(5)
+    embedder = LiteLLMEmbedder(model="m", quota=quota)
+    with pytest.raises(VectorBackendUnavailable, match="embed quota exceeded"):
+        await embedder.aembed(["big text that would cost more than the cap"])
+    assert calls == [], "litellm.aembedding must not be called once quota is blown"
+
+
+@pytest.mark.asyncio
+async def test_aembed_surfaces_litellm_error_as_unavailable(
+    sm: StateManager, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _install_fake_litellm(monkeypatch, raise_on_call=RuntimeError("upstream 503"))
+    embedder = LiteLLMEmbedder(model="m", quota=EmbedQuota(sm, daily_cap=1000))
+    with pytest.raises(VectorBackendUnavailable, match="embedding call failed"):
+        await embedder.aembed(["anything"])
+
+
+@pytest.mark.asyncio
+async def test_aembed_rejects_malformed_response(
+    sm: StateManager, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _install_fake_litellm(monkeypatch, malformed=True)
+    embedder = LiteLLMEmbedder(model="m", quota=EmbedQuota(sm, daily_cap=1000))
+    with pytest.raises(VectorBackendUnavailable, match="malformed embedding response"):
+        await embedder.aembed(["anything"])
+
+
+@pytest.mark.asyncio
+async def test_sync_and_async_produce_identical_output(
+    sm: StateManager, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Shared _parse_and_record ensures the two paths can't drift."""
+    vectors = [[0.5, -0.5, 0.25]]
+    _install_fake_litellm(monkeypatch, vectors=vectors, total_tokens=11)
+    quota = EmbedQuota(sm, daily_cap=1000)
+    embedder = LiteLLMEmbedder(model="m", quota=quota)
+
+    sync_out = embedder(["same text"])
+    async_out = await embedder.aembed(["same text"])
+
+    assert sync_out == async_out == vectors
+    # Both calls recorded against the same quota.
+    assert quota.used_today() == 22

--- a/tests/test_main_handler_async.py
+++ b/tests/test_main_handler_async.py
@@ -1,0 +1,73 @@
+"""Regression test for the Gemini-flagged blocking in the retrieval capability handler.
+
+Before this fix, `_planning_retrieval_handler` invoked `retrieve_context`
+(and therefore `litellm.embedding`) synchronously from the event loop,
+which meant a vector-retrieve could stall the swarm's async loop for
+seconds at a time. The fix dispatches the sync `retrieve_context` call
+through `asyncio.to_thread`; this test proves that a blocking
+`retrieve_context` no longer starves concurrent tasks.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+# `src.main` imports `google.adk.runners` at module scope; skip the whole
+# test module when ADK isn't installed (local env without heavy deps).
+pytest.importorskip("google.adk")
+
+from src.capabilities.contracts import CapabilityRequest
+
+
+@pytest.mark.asyncio
+async def test_planning_retrieval_handler_yields_event_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When `retrieve_context` blocks for 150ms, a concurrent async task
+    must still run in the meantime. Without the `asyncio.to_thread`
+    wrapper the handler would hog the loop and the other task couldn't
+    make progress until it returned."""
+    import src.main as main_mod
+
+    def _slow_retrieve(query):
+        time.sleep(0.15)  # simulates the blocking litellm.embedding call
+        return {"query": query.query, "corpus": query.corpus, "sources": []}
+
+    monkeypatch.setattr(main_mod, "retrieve_context", _slow_retrieve)
+
+    request = CapabilityRequest(
+        name="planning.retrieve_context",
+        arguments={"query": "phase gate", "corpus": ["specs"], "top_k": 3},
+    )
+
+    # Schedule the handler and a concurrent task that records its wake time.
+    handler_start = asyncio.get_event_loop().time()
+    concurrent_wake = asyncio.get_event_loop().time()  # overwritten below
+
+    async def _concurrent_task():
+        nonlocal concurrent_wake
+        # Multiple small sleeps so if the loop is hogged we see the delay.
+        for _ in range(10):
+            await asyncio.sleep(0.01)
+        concurrent_wake = asyncio.get_event_loop().time()
+
+    handler_task = asyncio.create_task(main_mod._planning_retrieval_handler(request))
+    concurrent_task = asyncio.create_task(_concurrent_task())
+
+    result = await handler_task
+    await concurrent_task
+
+    # The concurrent task's ~100ms of cumulative sleeps must complete while
+    # the handler's 150ms blocking sleep is still in flight — i.e., the
+    # concurrent task finished BEFORE the handler did. If the handler had
+    # blocked the loop, the concurrent task couldn't wake until the handler
+    # returned, putting `concurrent_wake` AFTER `handler_start + 150ms`.
+    elapsed_concurrent = concurrent_wake - handler_start
+    assert elapsed_concurrent < 0.14, (
+        f"concurrent task was starved; completed after {elapsed_concurrent:.3f}s. "
+        "Handler must dispatch retrieve_context through asyncio.to_thread."
+    )
+    assert result == {"query": "phase gate", "corpus": ["specs"], "sources": []}


### PR DESCRIPTION
Addresses Gemini's last outstanding high-severity review item from PR #13: `litellm.embedding` is a synchronous network call invoked from inside the swarm's async event loop via a sync capability handler, so every vector retrieve stalls the loop for seconds. When the vector path serves a real corpus, `_self_prompt_tick`, the dequeue loop, and other async agent tools all sit idle.

## Approach

Two independent pieces — either one alone unblocks the loop. Shipping both keeps a native-async path available for later callers.

### 1. Thread-pool wrapper at the capability handler

`src/main.py::_planning_retrieval_handler` is now `async def` and dispatches `retrieve_context` through `asyncio.to_thread`. Same pattern as the existing `_self_prompt_tick` and `GitHubTool._get_contents_with_retry` wrappers. `CapabilityService._execute_passthrough_capability` already awaits coroutine handlers via its `inspect.isawaitable(output)` branch, so this change is invisible to the capability plumbing.

### 2. Native async `LiteLLMEmbedder.aembed`

New `async def aembed(texts)` mirrors `__call__` but calls `litellm.aembedding` (same OpenAI envelope) without the thread hop. Future callers inside async handlers can skip `asyncio.to_thread` entirely; current retrieval path still routes through the sync `__call__` under the thread-pool wrapper.

### Extracted shared helpers

Refactored `LiteLLMEmbedder.__call__` into `_precheck → litellm.embedding → _parse_and_record`. Both sync and async paths now share quota accounting, import guarding, and response-shape parsing — they can't drift on token counting or error handling.

## Tests

**7 new** (283 total local green, up from 276; 2 skipped for missing optional deps):

- `tests/services/test_embedder.py`:
  - `_install_fake_litellm` now stubs both `embedding` and `aembedding`.
  - Six `aembed` tests mirror the sync coverage: vector return + token recording, estimate fallback without usage block, empty-batch short-circuit, quota rejection before the SDK call, upstream-error wrapping, malformed-response rejection.
  - One parity test asserts sync and async paths produce identical output for identical input.
- `tests/test_main_handler_async.py`:
  - Schedules the handler against a 150ms blocking fake `retrieve_context` and a concurrent task doing ~100ms of cumulative `asyncio.sleep(0.01)`.
  - Asserts the concurrent task wakes **before** the handler finishes — direct regression test for the Gemini-flagged behavior.
  - Skips cleanly when `google.adk` isn't installed (since `src/main` top-imports it).

## Checks

- [x] `pytest -q` — 283 green / 2 skipped (stable subset)
- [x] `ruff check src tests` — clean under CI-pinned 0.5.7
- [x] `ruff format --check src tests` — clean
- [x] `coverage report --fail-under=45` — passes
- [ ] CI run on this PR

Verification plan with real credentials (`Config.RETRIEVAL_BACKEND=vector`, `OPENROUTER_API_KEY` set): `_self_prompt_tick` continues firing during a vector retrieve — previously it stalled for the full embedding round-trip.

## Out of scope (explicit deferrals)

- Full async `VectorIndex` protocol (`aupsert` / `aquery` on the protocol itself + a native async `SqliteVecBackend`). Not needed until thread-pool overhead shows up in latency measurements.
- Making `retrieve_context` itself `async def` and rippling that through sync callers in `orchestrator.py` + tests.
- `litellm.aembedding` batching / connection-pool tuning.

https://claude.ai/code/session_01665TpXDGRoB8ipxn8n3on5