### PR TITLE
fix: stabilize autonomous runtime

### DIFF
--- a/docs/superpowers/plans/2026-04-18-swarm-runtime-error-remediation.md
+++ b/docs/superpowers/plans/2026-04-18-swarm-runtime-error-remediation.md
@@ -1,0 +1,334 @@
+# Swarm Runtime Error Remediation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate the current autonomous swarm runtime failures by aligning the remote-repository tool surface, routing self-prompt execution through the repo's robust planner path, and adding regression coverage for the confirmed failure modes.
+
+**Architecture:** The confirmed root causes are a tool-surface mismatch in the ADK agent instructions and an unreliable native ADK function-calling path for `elephant-alpha` on OpenRouter. The fix should keep ADK for agent composition, but move autonomous self-prompt tool execution onto the existing `src.planner.run_planner(...)` path that already repairs malformed JSON and executes tool calls explicitly.
+
+**Tech Stack:** Python 3.11, Google ADK, LiteLLM/OpenRouter, `json-repair`, `pytest`, `pytest-asyncio`
+
+---
+
+**Planning handoff**
+
+- **Approved spec path:** none for this debugging task; this plan is derived from confirmed runtime evidence in `swarm_self_prompt.log`
+- **In scope:** the autonomous/self-prompt runtime path in `src/main.py`, orchestrator/ideator instruction surfaces, remote repo exploration tool usage, and regression tests for the confirmed runtime failures
+- **Out of scope:** redesigning all agents, changing the target repo (`project-chimera`), or replacing ADK as the top-level runtime
+- **Known files/directories:** `src/main.py`, `src/planner.py`, `src/agents/orchestrator.py`, `src/agents/ideator.py`, `src/tools/github_tool.py`, `src/tools/dispatcher.py`, `src/testing/mock_llm.py`, `tests/test_runtime_capabilities.py`, `tests/test_sub_agents.py`
+
+### Task 1: Add regression coverage for the confirmed runtime failure modes
+
+**Files:**
+- Create: `tests/runtime/test_autonomous_runtime.py`
+- Test: `tests/runtime/test_autonomous_runtime.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+from src.agents.orchestrator import orchestrator_agent
+from src.main import _build_autonomous_prompt
+from src.services.runtime_strategy import should_use_planner_for_autonomous_run
+
+
+def test_autonomous_runtime_uses_planner_for_elephant_openrouter():
+    assert should_use_planner_for_autonomous_run("openrouter/elephant-alpha") is True
+
+
+def test_orchestrator_instruction_mentions_remote_repo_tools():
+    instruction = orchestrator_agent.instruction
+    assert "read_repo_file" in instruction
+    assert "list_repo_contents" in instruction
+
+
+def test_autonomous_prompt_uses_registered_remote_repo_tools():
+    prompt = _build_autonomous_prompt("project-chimera")
+    assert "list_repo_contents" in prompt
+    assert "read_repo_file" in prompt
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./venv/bin/python -m pytest tests/runtime/test_autonomous_runtime.py -q`
+Expected: FAIL with `ModuleNotFoundError` or missing-symbol assertions for `should_use_planner_for_autonomous_run` / `_build_autonomous_prompt`
+
+- [ ] **Step 3: Write minimal implementation scaffolding**
+
+```python
+# src/services/runtime_strategy.py
+def should_use_planner_for_autonomous_run(model_name: str) -> bool:
+    return model_name.startswith("openrouter/elephant")
+
+
+# src/main.py
+def _build_autonomous_prompt(repo_name: str) -> str:
+    return (
+        f"First, use 'list_repo_contents' to explore the '{repo_name}' repository. "
+        "Read key files using 'read_repo_file' and then create structured tasks."
+    )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./venv/bin/python -m pytest tests/runtime/test_autonomous_runtime.py -q`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/runtime/test_autonomous_runtime.py src/main.py src/services/runtime_strategy.py
+git commit -m "test: add autonomous runtime regression coverage"
+```
+
+### Task 2: Route autonomous self-prompt execution through the planner path
+
+**Files:**
+- Create: `src/services/runtime_strategy.py`
+- Modify: `src/main.py`
+- Test: `tests/runtime/test_autonomous_runtime.py`
+
+- [ ] **Step 1: Write the failing test for planner routing**
+
+```python
+import pytest
+
+import src.main as main_module
+
+
+@pytest.mark.asyncio
+async def test_process_prompt_uses_planner_for_autonomous_runs(monkeypatch):
+    calls = []
+
+    async def fake_run_planner(*, user_prompt: str, system_prompt: str, max_iterations: int):
+        calls.append((user_prompt, system_prompt, max_iterations))
+        return "DONE"
+
+    monkeypatch.setattr(main_module, "run_planner", fake_run_planner)
+
+    await main_module._run_autonomous_prompt_with_tools("prompt text")
+
+    assert calls == [("prompt text", main_module.AUTONOMOUS_SYSTEM_PROMPT, 8)]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./venv/bin/python -m pytest tests/runtime/test_autonomous_runtime.py::test_process_prompt_uses_planner_for_autonomous_runs -q`
+Expected: FAIL with `AttributeError` because `_run_autonomous_prompt_with_tools` and `AUTONOMOUS_SYSTEM_PROMPT` do not exist yet
+
+- [ ] **Step 3: Write minimal planner-backed runtime implementation**
+
+```python
+# src/main.py
+from src.planner import run_planner
+
+AUTONOMOUS_SYSTEM_PROMPT = (
+    "You are the Cognitive Foundry autonomous runtime. "
+    "Use registered tools exactly as named. "
+    "For remote GitHub repo exploration, use read_repo_file and list_repo_contents."
+)
+
+
+async def _run_autonomous_prompt_with_tools(user_prompt: str) -> str:
+    return await run_planner(
+        user_prompt=user_prompt,
+        system_prompt=AUTONOMOUS_SYSTEM_PROMPT,
+        max_iterations=8,
+    )
+```
+
+- [ ] **Step 4: Wire `run_swarm_loop()` to the planner-backed path**
+
+```python
+# src/main.py
+async def run_swarm_loop(session_service, session, runner) -> None:
+    initial_query = _build_autonomous_prompt("project-chimera")
+    response = await _run_autonomous_prompt_with_tools(initial_query)
+    print(f"Swarm: {response}")
+    logger.info(f"Swarm response: {response}", extra={"session_id": session.id})
+    ...
+```
+
+- [ ] **Step 5: Run focused tests**
+
+Run: `./venv/bin/python -m pytest tests/runtime/test_autonomous_runtime.py tests/test_runtime_capabilities.py -q`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/main.py src/services/runtime_strategy.py tests/runtime/test_autonomous_runtime.py
+git commit -m "feat: route autonomous runtime through planner"
+```
+
+### Task 3: Align orchestrator and ideator instructions with the actual remote repo tool surface
+
+**Files:**
+- Modify: `src/agents/orchestrator.py`
+- Modify: `src/agents/ideator.py`
+- Test: `tests/runtime/test_autonomous_runtime.py`
+
+- [ ] **Step 1: Write the failing instruction-surface test**
+
+```python
+from src.agents.ideator import ideator_agent
+from src.agents.orchestrator import orchestrator_agent
+
+
+def test_instruction_surface_uses_remote_repo_tools_not_fake_capabilities():
+    orchestrator_text = orchestrator_agent.instruction
+    ideator_text = ideator_agent.instruction
+
+    assert "read_repo_file" in orchestrator_text
+    assert "list_repo_contents" in orchestrator_text
+    assert "read_repo_file" in ideator_text
+    assert "list_repo_contents" in ideator_text
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./venv/bin/python -m pytest tests/runtime/test_autonomous_runtime.py::test_instruction_surface_uses_remote_repo_tools_not_fake_capabilities -q`
+Expected: FAIL because the orchestrator instruction currently emphasizes `execute_capability` and does not teach the remote GitHub tool names clearly enough
+
+- [ ] **Step 3: Update the instructions minimally**
+
+```python
+# src/agents/orchestrator.py
+instruction = """You are the master orchestrator of the Cognitive Foundry.
+For remote GitHub repository exploration, use read_repo_file and list_repo_contents directly.
+Reserve execute_capability for shared local runtime capabilities like swarm.status, repo.read_file, and repo.list_directory.
+Use retrieve_planning_context only for specs, plans, and history in this repository.
+"""
+
+
+# src/agents/ideator.py
+instruction = """You are the Ideator of the Cognitive Foundry.
+When analyzing a remote GitHub repository, use read_repo_file and list_repo_contents.
+Do not treat list_repo_contents as a capability name.
+Use create_structured_task only after you have concrete repository evidence.
+"""
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `./venv/bin/python -m pytest tests/runtime/test_autonomous_runtime.py tests/test_sub_agents.py -q`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agents/orchestrator.py src/agents/ideator.py tests/runtime/test_autonomous_runtime.py
+git commit -m "fix: align swarm instructions with remote repo tools"
+```
+
+### Task 4: Add a bounded fallback for malformed ADK tool-call JSON during runtime execution
+
+**Files:**
+- Modify: `src/main.py`
+- Modify: `src/observability/logger.py`
+- Test: `tests/runtime/test_autonomous_runtime.py`
+
+- [ ] **Step 1: Write the failing fallback test**
+
+```python
+import json
+import pytest
+
+import src.main as main_module
+
+
+@pytest.mark.asyncio
+async def test_process_prompt_falls_back_on_tool_call_json_decode_error(monkeypatch):
+    class BrokenRunner:
+        def run_async(self, **kwargs):
+            async def _events():
+                raise json.JSONDecodeError("bad tool call", "{", 1)
+                yield
+            return _events()
+
+    fallback_calls = []
+
+    async def fake_run_planner(*, user_prompt: str, system_prompt: str, max_iterations: int):
+        fallback_calls.append(user_prompt)
+        return "recovered"
+
+    monkeypatch.setattr(main_module, "run_planner", fake_run_planner)
+
+    await main_module.process_prompt(BrokenRunner(), type("S", (), {"id": "s1"})(), "prompt text")
+
+    assert fallback_calls == ["prompt text"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./venv/bin/python -m pytest tests/runtime/test_autonomous_runtime.py::test_process_prompt_falls_back_on_tool_call_json_decode_error -q`
+Expected: FAIL because `process_prompt()` currently only logs the error and does not recover
+
+- [ ] **Step 3: Implement the narrow fallback**
+
+```python
+# src/main.py
+except json.JSONDecodeError as e:
+    span.record_exception(e)
+    span.set_status(Status(StatusCode.ERROR, str(e)))
+    logger.exception("ADK tool-call JSON decode failure; retrying via planner")
+    fallback = await _run_autonomous_prompt_with_tools(user_query)
+    print(f"Swarm: {fallback}")
+    logger.info(f"Swarm response: {fallback}", extra={"session_id": session.id})
+```
+
+- [ ] **Step 4: Run focused tests**
+
+Run: `./venv/bin/python -m pytest tests/runtime/test_autonomous_runtime.py tests/test_runtime_capabilities.py -q`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main.py src/observability/logger.py tests/runtime/test_autonomous_runtime.py
+git commit -m "fix: fall back when ADK tool-call JSON is malformed"
+```
+
+### Task 5: Verify the autonomous swarm end-to-end against the confirmed reproduction
+
+**Files:**
+- Modify: `tests/runtime/test_autonomous_runtime.py`
+- Test: `tests/runtime/test_autonomous_runtime.py`
+
+- [ ] **Step 1: Add an end-to-end smoke test for the repaired runtime path**
+
+```python
+import pytest
+
+import src.main as main_module
+
+
+@pytest.mark.asyncio
+async def test_autonomous_prompt_runs_without_runtime_exception(monkeypatch):
+    async def fake_run_planner(*, user_prompt: str, system_prompt: str, max_iterations: int):
+        return "DONE: explored repository"
+
+    monkeypatch.setattr(main_module, "run_planner", fake_run_planner)
+
+    result = await main_module._run_autonomous_prompt_with_tools(
+        main_module._build_autonomous_prompt("project-chimera")
+    )
+
+    assert result == "DONE: explored repository"
+```
+
+- [ ] **Step 2: Run the automated tests**
+
+Run: `./venv/bin/python -m pytest tests/runtime/test_autonomous_runtime.py tests/test_sub_agents.py tests/test_runtime_capabilities.py -q`
+Expected: PASS
+
+- [ ] **Step 3: Run the runtime reproduction manually**
+
+Run: `AUTONOMOUS_MODE=true ./venv/bin/python -m src.main`
+Expected: the swarm stays up, prints `Cognitive Foundry Swarm Active`, and no longer crashes with `JSONDecodeError` while handling the initial self-prompt
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/runtime/test_autonomous_runtime.py
+git commit -m "test: verify autonomous swarm runtime path"
+```

--- a/docs/superpowers/specs/2026-04-18-agent-harnesses-design.md
+++ b/docs/superpowers/specs/2026-04-18-agent-harnesses-design.md
@@ -1,0 +1,249 @@
+# Design Specification: Dedicated Thin Harness Layer for the ADK Swarm
+
+**Date:** 2026-04-18
+**Status:** Approved for planning
+**Topic:** Go/no-go recommendation on adopting a dedicated agent harness layer
+**Decision:** **Go**, with a thin harness layer that remains subordinate to Google ADK
+
+## 1. Executive Summary
+
+This repository should adopt a **dedicated thin harness layer** around the existing ADK runtime. The current system already contains most of the ingredients of a production harness—session persistence, tool mediation, retrieval, guardrails, observability, and task state—but those concerns are scattered across the entrypoint and service modules instead of being owned by one explicit runtime boundary.
+
+The recommendation is **not** to introduce a new top-level runtime, workflow engine, or competing orchestrator. The recommendation is to keep **Google ADK** as the control plane and add a harness layer beneath `src/main.py` and around the ADK `Runner` so production concerns are enforced consistently.
+
+## 2. Problem Statement
+
+The system currently behaves like a **partial harness** rather than a full one:
+
+- `src/main.py` wires tools, capabilities, telemetry, session creation, and the ADK runner directly.
+- `src/tools/dispatcher.py` and `src/capabilities/*` already form a tool/capability gateway, but they are not treated as the canonical runtime boundary.
+- `src/state.py`, `src/services/session_store.py`, retrieval, cost tracking, and history each persist state independently.
+- Guardrails and observability exist, but they are point solutions rather than centrally owned runtime policies.
+
+This fragmentation makes it harder to reason about identity, policy enforcement, memory/state coordination, auditability, and long-running reliability.
+
+## 3. Goals
+
+- Make the swarm's production infrastructure explicit without replacing ADK.
+- Centralize runtime context, state coordination, tool mediation, policy enforcement, and observability.
+- Keep the orchestrator and specialist agents focused on reasoning and delegation rather than infrastructure concerns.
+- Improve decision-grade clarity for future planning by defining what the harness owns and what it must never own.
+- Preserve a medium-change migration path that does not require a new runtime or service boundary.
+
+## 4. Non-Goals
+
+- Replacing Google ADK as the control plane.
+- Moving orchestration logic out of `src/agents/orchestrator.py`.
+- Introducing a second top-level runner, external harness daemon, or sidecar runtime.
+- Pulling prompts, delegation policy, or business logic into the harness layer.
+- Solving enterprise-grade multi-tenancy in the first iteration.
+
+## 5. Current-State Evidence
+
+### 5.1 Harness-like capabilities already present
+
+1. **ADK control plane exists now**
+   - `src/main.py` boots the runtime, creates `SQLiteSessionService`, creates the ADK `Runner`, and executes the orchestrator.
+   - `src/services/session_store.py` re-exports ADK's SQLite session service.
+
+2. **Multi-agent routing already exists**
+   - `src/agents/orchestrator.py` delegates work to specialist agents.
+
+3. **Tool and capability mediation already exists**
+   - `src/tools/dispatcher.py` provides tool registration, capability routing, standard result envelopes, and concurrency limits.
+   - `src/capabilities/service.py` and `src/capabilities/registry.py` provide a narrow execution surface.
+
+4. **Persistence already exists, but across multiple stores**
+   - ADK session storage via SQLite.
+   - JSON task/event state in `src/state.py`.
+   - File-backed queue/control-plane state in `src/cli/swarm_ctl.py`.
+   - Metrics, cost, and history in separate observability services.
+
+5. **Retrieval and memory-like behavior already exists**
+   - `src/services/retrieval_context.py` validates and exposes planning retrieval.
+
+6. **Guardrails already exist**
+   - Filesystem restrictions in `src/tools/filesystem.py`.
+   - Output/content controls and sandboxing in related tool modules.
+
+7. **Observability already exists**
+   - `src/observability/adk_callbacks.py` and related telemetry/logger modules provide traces, metrics, and logging.
+
+### 5.2 Current gaps
+
+1. **Split-brain persistence**
+   - State, session, queue, metrics, and audit concerns are persisted through separate mechanisms with no unified abstraction.
+
+2. **Identity and authorization are not harness-owned**
+   - Runtime ingress uses hardcoded or weakly propagated user identity today.
+
+3. **Cross-cutting concerns are embedded in the entrypoint**
+   - `src/main.py` owns too much runtime assembly and policy-adjacent behavior.
+
+4. **Memory is narrow**
+   - Retrieval is planning-focused and not yet a general runtime/session memory boundary.
+
+5. **Reliability controls are local, not systemic**
+   - File-based state writes and queueing are simple and effective for today, but not governed through one runtime contract.
+
+6. **Observability is present, but not unified as a run envelope**
+   - Logs, traces, metrics, and audit semantics are not coordinated through a single harness surface.
+
+## 6. Recommendation
+
+## **Go**
+
+Adopt a **dedicated thin harness layer** because:
+
+1. The repository already has most of the necessary ingredients.
+2. The missing work is mostly consolidation and ownership, not invention.
+3. A thin harness matches the user's medium-change tolerance.
+4. The existing architecture already prefers ADK as the sovereign runtime.
+
+## **No-go only if**
+
+The desired outcome changes into one of these:
+
+- a separate runtime or sidecar service becomes mandatory,
+- the harness is expected to own agent reasoning or orchestration,
+- or immediate hard-isolation/multi-tenant guarantees are required.
+
+Under those conditions, the system would no longer be adding a thin harness; it would be replacing the current runtime shape.
+
+## 7. Proposed Architecture
+
+### 7.1 Placement
+
+The harness should sit **under the entrypoint and around ADK runtime wiring**:
+
+```text
+prompt ingress
+    |
+src/main.py
+    |
+HarnessRuntime
+    |
+ADK Runner
+    |
+orchestrator + specialist agents
+```
+
+This keeps ADK as the only control plane while making the harness the explicit owner of runtime infrastructure.
+
+### 7.2 Ownership boundaries
+
+The harness should own:
+
+1. **Runtime context**
+   - run/session metadata
+   - trace correlation
+   - ingress identity and request metadata
+
+2. **Persistence coordination**
+   - ADK session persistence
+   - task/event state coordination
+   - audit and artifact write paths
+
+3. **Tool mediation**
+   - capability execution
+   - concurrency limits
+   - standard envelopes
+   - policy checks before tool execution
+
+4. **Memory and retrieval boundary**
+   - retrieval adapters
+   - future episodic/session memory
+   - caching and corpus policy
+
+5. **Guardrails and policy**
+   - filesystem policy
+   - output/content controls
+   - future authn/authz, budget, and rate policies
+
+6. **Observability**
+   - callback setup
+   - trace/log/metric correlation
+   - audit linkage between runs, tools, and state changes
+
+The harness should **not** own:
+
+- agent prompts,
+- delegation policy,
+- business logic,
+- or a second runtime loop.
+
+### 7.3 Target module shape
+
+One reasonable target is:
+
+```text
+src/
+  harness/
+    runtime.py
+    ingress.py
+    context.py
+    persistence.py
+    memory.py
+    tool_gateway.py
+    guardrails.py
+    observability.py
+```
+
+This is a design target, not a requirement for a single-step refactor. The plan may keep some existing modules in place and place harness ownership over them before moving code physically.
+
+## 8. Runtime Flow
+
+The intended runtime flow is:
+
+1. A prompt enters through CLI or queue ingestion.
+2. The harness establishes a run context with identity, session, and trace metadata.
+3. The harness builds or prepares the ADK runner and injects shared runtime services.
+4. The orchestrator executes normally through ADK.
+5. Tool calls, retrieval, and state-affecting operations pass through harness-owned mediation.
+6. The harness emits consistent telemetry, audit information, and policy decisions for the run.
+
+This flow keeps the orchestrator focused on reasoning while the harness becomes the production control surface around it.
+
+## 9. Validation and Research Frame
+
+This design is intentionally framed as a **decision-grade architecture recommendation**, not an immediate implementation plan. The next planning step should validate the recommendation through a bounded research frame:
+
+1. **Responsibility inventory**
+   - Map current harness-like responsibilities to concrete modules.
+
+2. **Minimum viable harness surface**
+   - Define the thinnest useful runtime contract that can wrap existing services without introducing a second control plane.
+
+3. **Gap verification**
+   - Confirm the most important missing capabilities: identity propagation, centralized policy, unified run context, persistence coordination, and audit consistency.
+
+4. **Migration boundary checks**
+   - Ensure prompts, orchestration logic, and agent business behavior remain outside the harness.
+
+5. **Exit criteria for the recommendation**
+   - If the thin layer can absorb cross-cutting runtime concerns without competing with ADK, the recommendation remains **go**.
+   - If achieving those goals would require a separate runtime or major control-plane replacement, revisit the recommendation.
+
+## 10. Risks and Trade-offs
+
+### 10.1 Main risk: creating a shadow runtime
+
+This is the architectural failure mode to avoid. The harness must never become a second orchestrator or a competing session engine.
+
+### 10.2 Added indirection
+
+The harness adds one more layer of abstraction, but that trade-off is justified because `src/main.py` currently mixes bootstrapping, runtime policy, and assembly concerns.
+
+### 10.3 Migration complexity
+
+The migration should be incremental. The harness should first consolidate runtime assembly, context propagation, and tool mediation before broader persistence or memory work.
+
+## 11. Planning Readiness
+
+This spec is intentionally scoped for a **single planning track**:
+
+- decide the initial harness boundary,
+- define what existing modules move under harness ownership first,
+- and produce a phased migration sequence that keeps ADK as the top-level runtime.
+
+The first plan should not include unrelated refactors or a second runtime architecture.

--- a/src/agents/critic.py
+++ b/src/agents/critic.py
@@ -13,7 +13,6 @@ if Config.TEST_MODE:
 else:
     from google.adk.models.lite_llm import LiteLlm
 
-# Tool-capable model for Critic (function calling required for evaluate, batch_execute, etc.)
 tool_model = LiteLlm(
     model=Config.OPENROUTER_TOOL_MODEL,
     api_key=Config.OPENROUTER_API_KEY,
@@ -24,6 +23,7 @@ tool_model = LiteLlm(
 async def evaluate(staged_path: str) -> dict:
     """
     Reviews staged Python code by executing it in a sandbox.
+
     Args:
         staged_path: Path to the staged Python file to evaluate.
     """
@@ -31,7 +31,7 @@ async def evaluate(staged_path: str) -> dict:
         return {"status": "FAIL", "reason": "Not a python file"}
 
     try:
-        with open(staged_path) as f:
+        with open(staged_path, "r", encoding="utf-8") as f:
             code = f.read()
 
         result = await execute_python_code(code)
@@ -48,8 +48,6 @@ async def review_pr(pr_number: int) -> dict:
     from src.tools.github_tool import GitHubTool
 
     gh = GitHubTool()
-    # In a real implementation, fetch PR diff and analyze
-    # For now, submit an automated review
     result = await gh.review_pull_request(
         pr_number=pr_number,
         body="Autonomous Critic review: basic safety checks passed.",
@@ -68,22 +66,7 @@ def get_review_graph_decision(
     builder_attempts: int = 1,
     max_retries: int = 2,
 ) -> dict:
-    """Validate a review verdict and return a bounded graph transition decision.
-
-    Combines the shared review-verdict contract with the workflow graph so
-    the critic agent can emit both a typed verdict *and* an explicit routing
-    decision (stop / rework / block) in one call.
-
-    Args:
-        payload:          Raw verdict dict with at minimum ``status`` and
-                          ``summary`` keys.
-        builder_attempts: How many times Builder has already attempted this
-                          task.  Used to evaluate the retry budget.
-        max_retries:      Maximum rework attempts before the loop stops.
-
-    Returns:
-        A ``GraphDecision`` dict with ``next_step`` and ``reason``.
-    """
+    """Return the bounded review-loop decision for a validated verdict."""
     verdict = normalize_review_verdict(payload)
     decision: GraphDecision = run_review_rework_cycle(
         ReviewLoopState(
@@ -102,15 +85,14 @@ critic_agent = Agent(
     description="Reviews code and staged tools for safety and quality",
     instruction="""You are the Critic of the Cognitive Foundry.
 Your job is to review code and staged tools for safety and quality.
-Use the batch_execute tool to run multiple validation tests or code snippets in parallel
-using 'tool_name': 'execute_python_code'.
-Alternatively, use the evaluate tool to run a single staged Python file in a sandbox.
+Use the batch_execute tool to run multiple validation steps in parallel.
+Alternatively, use evaluate to run a single staged Python file in a sandbox.
 Use create_review_verdict to emit a typed review verdict (pass/retry/block).
-Use get_review_graph_decision to emit both a verdict and a bounded routing decision
-in one step — this is preferred when Builder rework is a possibility.""",
+Use get_review_graph_decision when Builder rework is a possibility so the review returns an explicit bounded routing decision.""",
     tools=[
         batch_execute,
         evaluate,
+        review_pr,
         create_review_verdict,
         get_review_graph_decision,
         execute_python_code,

--- a/src/agents/ideator.py
+++ b/src/agents/ideator.py
@@ -1,16 +1,15 @@
 import asyncio
-from datetime import UTC, datetime
-
+from typing import List, Any
+from datetime import datetime, timezone
 from google.adk.agents import Agent
-
-from src.config import Config
-from src.services.agent_decisions import build_task_proposal
-from src.state import StateManager
-from src.tools.dispatcher import batch_execute
-from src.tools.filesystem import list_directory, read_file
-from src.tools.github_tool import GitHubTool
 from src.tools.scraper import ScraperTool
+from src.tools.github_tool import GitHubTool
+from src.state import StateManager
+from src.config import Config
 from src.tools.web_search import search_web
+from src.tools.dispatcher import batch_execute
+from src.tools.filesystem import read_file, list_directory
+from src.services.agent_decisions import build_task_proposal
 
 if Config.TEST_MODE:
     from src.testing.mock_llm import MockLiteLlm as LiteLlm
@@ -26,26 +25,22 @@ tool_model = LiteLlm(
 
 # Initialize core services
 if Config.TEST_MODE:
-
     class MockScraper:
-        async def scrape(self, url):
-            return "Mock content for testing"
-
+        async def scrape(self, url): return "Mock content for testing"
     scraper_tool = MockScraper()
 else:
     scraper_tool = ScraperTool(allowlist=["github.com", "google.com"])
 github_tool = GitHubTool()
 state_manager = StateManager()
 
-
 async def create_structured_task(
-    title: str,
-    description: str,
-    acceptance_criteria: list[str],
-    priority: int = 3,
+    title: str, 
+    description: str, 
+    acceptance_criteria: List[str], 
+    priority: int = 3, 
     complexity: str = "medium",
     suggested_agent: str = "Builder",
-    tags: list[str] = None,
+    tags: List[str] = None
 ) -> str:
     """
     Creates a high-quality, actionable task in the swarm state.
@@ -74,36 +69,43 @@ async def create_structured_task(
         "complexity": complexity,
         "suggested_agent": proposal.recommended_agent,
         "tags": tags or [],
-        "created_at": datetime.now(UTC).isoformat(),
-        "source": "Ideator",
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "source": "Ideator"
     }
-
+    
     state_manager.set_task(task_id, task_data, agent="Ideator")
-
+    
     # Also track in GitHub for visibility
-    body = f"## Summary\n{proposal.summary}\n\n## Description\n{proposal.description}\n\n## Acceptance Criteria\n"
+    body = f"## Summary\n{proposal.title}\n\n## Description\n{proposal.description}\n\n## Acceptance Criteria\n"
     body += "\n".join([f"- [ ] {ac}" for ac in proposal.acceptance_criteria])
     body += (
         f"\n\n**Priority**: {priority} | **Complexity**: {complexity} "
         f"| **Suggested Agent**: {proposal.recommended_agent}"
     )
-
-    await github_tool.create_issue(title=f"[SWARM TASK] {proposal.title}", body=body)
-
+    
+    await github_tool.create_issue(
+        title=f"[SWARM TASK] {proposal.title}",
+        body=body
+    )
+    
     return f"Successfully created structured task: {task_id}"
-
 
 ideator_agent = Agent(
     name="Ideator",
     model=tool_model,
     description="Proactively scouts technical trends and plans autonomous tasks",
-    instruction="""You are the Ideator of the Cognitive Foundry.
+    instruction="""You are the Ideator of the Cognitive Foundry. 
     Your mission is to find high-impact opportunities for codebase improvement, new features, or technical debt reduction.
 
     STRATEGY:
     1. RESEARCH: Use 'search_web' and 'batch_execute' to scout for latest trends (e.g., "latest FastAPI patterns", "React 19 features").
-    2. ANALYZE: Read relevant project files using 'read_repo_file' to identify where these trends could be applied.
-    3. PLAN: Use 'create_structured_task' to turn findings into ACTIONABLE work.
+    2. ANALYZE: For remote GitHub repository exploration, start with 'list_repo_contents' and inspect files with 'read_repo_file'.
+    3. PLAN: Use 'create_structured_task' to turn findings into ACTIONABLE work. 
+
+    REMOTE VS LOCAL BOUNDARY:
+    - For the remote GitHub repository, use 'list_repo_contents' and 'read_repo_file' directly.
+    - Use 'list_directory' and 'read_file' only for local workspace files.
+    - Do not use retrieve_planning_context or execute_capability to explore the remote repository; retrieve_planning_context is only for local specs, plans, and history.
 
     TASK GUIDELINES:
     - BE SPECIFIC: Avoid vague titles like "Improve code". Use "Refactor Error Handling in src/main.py".
@@ -113,12 +115,12 @@ ideator_agent = Agent(
     ALWAYS use 'batch_execute' when you need to perform more than one search or file read to maximize throughput.
     """,
     tools=[
-        batch_execute,
-        search_web,
-        create_structured_task,
-        read_file,
-        list_directory,
-        github_tool.read_repo_file,
-        github_tool.list_repo_contents,
-    ],
+        batch_execute, 
+        search_web, 
+        create_structured_task, 
+        read_file, 
+        list_directory, 
+        github_tool.read_repo_file, 
+        github_tool.list_repo_contents
+    ]
 )

--- a/src/agents/orchestrator.py
+++ b/src/agents/orchestrator.py
@@ -1,6 +1,8 @@
 from google.adk.agents import Agent
 
 from src.config import Config
+from src.services.agent_decisions import choose_delegate
+from src.services.retrieval_context import retrieve_planning_context
 from src.tools.dispatcher import batch_execute, execute_capability
 from src.tools.smithery_bridge import call_smithery_tool
 from src.tools.web_search import search_web
@@ -15,82 +17,59 @@ from src.agents.critic import critic_agent
 from src.agents.finops import finops_agent
 from src.agents.ideator import create_structured_task, ideator_agent
 from src.agents.pulse import pulse_agent
-from src.services.agent_decisions import choose_delegate
-from src.services.retrieval_context import retrieve_planning_context
 
-# Tool-capable model for orchestration (function calling required)
 tool_model = LiteLlm(
-    model=Config.OPENROUTER_TOOL_MODEL,
+    model=Config.OPENROUTER_MODEL,
     api_key=Config.OPENROUTER_API_KEY,
     api_base=Config.OPENROUTER_API_BASE,
 )
 
 
 def route_task(task_id: str, agent_name: str | None = None, user_goal: str | None = None) -> str:
-    """
-    Routes a task to a specific agent in the swarm.
-    Args:
-        task_id: The ID of the task to route.
-        agent_name: The name of the target agent (e.g., 'Builder', 'Critic').
-        user_goal: Optional natural-language goal used for typed fallback routing.
-    """
     if user_goal:
         decision = choose_delegate(
             user_goal=user_goal,
             available_agents=["Ideator", "Builder", "Critic", "Pulse", "FinOps"],
         )
         agent_name = decision.target_agent
+
     if not agent_name:
-        raise ValueError("agent_name or user_goal is required")
+        agent_name = "Ideator"
+
     return f"Task {task_id} has been successfully routed to the {agent_name} agent."
 
-
-from src.tools.filesystem import list_directory, read_file
-from src.tools.github_tool import list_repo_contents, read_repo_file
-
-# ... existing code ...
 
 orchestrator_agent = Agent(
     name="Orchestrator",
     model=tool_model,
     instruction="""You are the master orchestrator of the Cognitive Foundry.
-You have a team of specialized sub-agents. To delegate tasks, you MUST use the transfer_to_agent tool.
-Do NOT try to call the agent names directly as functions.
 
-Concurrency & Efficiency Rules:
-- If a task involves multiple independent operations (e.g., searching for 3 different terms, reading multiple files, or checking status of 5 tasks), YOU MUST USE 'batch_execute' to run them in parallel.
-- Prefer 'execute_capability' for shared runtime operations such as swarm status, guarded repo reads/listings, and Smithery-backed helpers that should return the standard capability envelope.
-- Parallel execution is the default for independent data gathering. Do NOT run them one-by-one.
+Delegate tasks to your specialized sub-agents based on the user's request:
+- For ideation, trend scouting, or proactive planning, transfer to Ideator.
+- For building new tools or code, transfer to Builder.
+- For reviewing code or safety checks, transfer to Critic.
+- For health checks or status reports, transfer to Pulse.
+- For budget or cost questions, transfer to FinOps.
 
-Analysis Rules:
-- Before ideation, prefer execute_capability(name='repo.list_directory', ...) and execute_capability(name='repo.read_file', ...) to understand the project structure and context.
-- For parallel capability lookups, use batch_execute with tool_name='execute_capability'.
-- Retrieval is opt-in. When current-session context is insufficient for planning or delegation, use retrieve_planning_context(query='<goal>', corpus=['specs', 'plans', 'history']) before routing work.
-- Do not use retrieval by default and do not broaden it beyond specs, plans, and history.
-
-Delegation rules:
-- For ideation, trend scouting, or proactive planning → transfer_to_agent(agent_name='Ideator')
-- For building new tools or code → transfer_to_agent(agent_name='Builder')
-- For reviewing code or safety checks → transfer_to_agent(agent_name='Critic')
-- For health checks or status reports → transfer_to_agent(agent_name='Pulse')
-- For budget or cost questions → transfer_to_agent(agent_name='FinOps')
-
-You also have access to the Smithery marketplace.
-Prefer execute_capability(name='smithery.call_tool', ...) to access external services like Slack, Postgres, or Memory.
-Common servers: 'neon' (Postgres), 'node2flow/slack' (Slack).
-""",
+For remote GitHub repository exploration in the autonomous runtime, use read_repo_file and list_repo_contents directly.
+Use execute_capability for shared operational and guarded local capabilities, not for browsing the remote GitHub repository.
+Before ideation or specialist routing, use retrieve_planning_context only for local specs, plans, and history when current-session context is insufficient.
+Continue using batch_execute for independent parallel work.
+You also have access to the Smithery marketplace when an external tool is needed.""",
     tools=[
-        route_task,
+        batch_execute,
         execute_capability,
         retrieve_planning_context,
-        call_smithery_tool,
-        batch_execute,
-        create_structured_task,
+        route_task,
         search_web,
-        read_file,
-        list_directory,
-        read_repo_file,
-        list_repo_contents,
+        call_smithery_tool,
+        create_structured_task,
     ],
-    sub_agents=[ideator_agent, builder_agent, critic_agent, pulse_agent, finops_agent],
+    sub_agents=[
+        ideator_agent,
+        builder_agent,
+        critic_agent,
+        pulse_agent,
+        finops_agent,
+    ],
 )

--- a/src/config.py
+++ b/src/config.py
@@ -49,6 +49,12 @@ class Settings(BaseSettings):
     llamaindex_enabled: bool = False
     token_quota_per_task: int = 50000
 
+    langfuse_enabled: bool = False
+    helicone_enabled: bool = False
+    agentops_enabled: bool = False
+    mlflow_enabled: bool = False
+    sentry_dsn: str | None = None
+
     openrouter_api_key: str | None = None
     openrouter_api_base: str = "https://openrouter.ai/api/v1"
     openrouter_model: str = "openrouter/elephant-alpha"
@@ -99,6 +105,11 @@ class Config:
     LANGGRAPH_ENABLED = _settings.langgraph_enabled
     LLAMAINDEX_ENABLED = _settings.llamaindex_enabled
     TOKEN_QUOTA_PER_TASK = _settings.token_quota_per_task
+    LANGFUSE_ENABLED = _settings.langfuse_enabled
+    HELICONE_ENABLED = _settings.helicone_enabled
+    AGENTOPS_ENABLED = _settings.agentops_enabled
+    MLFLOW_ENABLED = _settings.mlflow_enabled
+    SENTRY_DSN = _settings.sentry_dsn
     OPENROUTER_API_KEY = _settings.openrouter_api_key
     OPENROUTER_API_BASE = _settings.openrouter_api_base
     OPENROUTER_MODEL = _settings.openrouter_model

--- a/src/main.py
+++ b/src/main.py
@@ -1,11 +1,14 @@
 import asyncio
+import json
 import os
 
 from google.adk.runners import Runner
 from google.genai import types
 
 from src.agents.orchestrator import orchestrator_agent
-from src.capabilities.contracts import CapabilityRequest
+from src.capabilities.contracts import CapabilityRequest, CapabilityResult
+from src.config import Config
+from src.planner import run_planner
 from src.services.retrieval_context import (
     PLANNING_RETRIEVAL_CAPABILITY,
     RetrievalQuery,
@@ -13,6 +16,7 @@ from src.services.retrieval_context import (
     retrieve_planning_context,
 )
 from src.services.session_store import SQLiteSessionService
+from src.services.runtime_strategy import should_use_planner_for_autonomous_run
 from src.tools.dispatcher import (
     _register_capability,
     execute_capability,
@@ -39,22 +43,10 @@ register_tool("list_repo_contents", list_repo_contents)
 register_tool("retrieve_planning_context", retrieve_planning_context)
 
 
-async def _planning_retrieval_handler(request: CapabilityRequest) -> dict[str, object]:
-    """Async capability handler for `planning.retrieve_context`.
-
-    `retrieve_context` is synchronous and, in vector mode, blocks on
-    `litellm.embedding` for seconds per query. Dispatch it through
-    `asyncio.to_thread` so the swarm event loop stays responsive —
-    `_self_prompt_tick`, the dequeue loop, and other async agent tools
-    continue making progress while the embedding call is in flight.
-
-    `CapabilityService._execute_passthrough_capability` checks
-    `inspect.isawaitable(output)` and awaits when the handler returns
-    a coroutine, so this change is invisible to the capability
-    plumbing.
-    """
+async def _planning_retrieval_handler(request: CapabilityRequest) -> CapabilityResult:
     query = RetrievalQuery.model_validate(request.arguments)
-    return await asyncio.to_thread(retrieve_context, query)
+    payload = await asyncio.to_thread(retrieve_context, query)
+    return CapabilityResult.ok(payload=payload, source_backend="retrieval")
 
 
 _register_capability(
@@ -78,8 +70,8 @@ from src.cli.swarm_ctl import (
     is_shutdown_requested,
     write_pid,
 )
-from src.config import Config
 from src.observability.adk_callbacks import ObservabilityCallback
+from src.observability.litellm_callbacks import setup_callbacks
 from src.observability.logger import configure_logging, get_logger, set_session_id, set_trace_id
 from src.services import self_prompt as _self_prompt
 from src.state import StateManager
@@ -113,21 +105,101 @@ async def _self_prompt_tick(sm: StateManager, *, interval_sec: float = 60.0) -> 
         await asyncio.sleep(interval_sec)
     logger.info("self_prompt.tick: stopped (shutdown or off-switch)")
 
+AUTONOMOUS_SYSTEM_PROMPT = (
+    "You are the Cognitive Foundry autonomous runtime. "
+    "Use registered tools exactly as named. "
+    "For remote GitHub repository exploration, use read_repo_file and list_repo_contents."
+)
+
+
+def _build_autonomous_prompt(repo_name: str) -> str:
+    """Build the autonomous self-prompt for remote repository exploration."""
+    return (
+        f"First, use 'list_repo_contents' to explore the '{repo_name}' repository. "
+        "Read key files in that repository with 'read_repo_file' to understand its current state. "
+        "Then, identify high-priority improvements or missing features, "
+        "create structured tasks for them, and start the proactive ideation process. "
+        "Remember: You are the Cognitive Foundry swarm, and this repository is your development target."
+    )
+
+
+async def _run_autonomous_prompt_with_tools(user_prompt: str) -> str:
+    """Run the autonomous self-prompt through the planner-backed tool loop."""
+    return await run_planner(
+        user_prompt=user_prompt,
+        system_prompt=AUTONOMOUS_SYSTEM_PROMPT,
+        max_iterations=8,
+    )
+
+
+def _should_fallback_to_planner(exc: BaseException) -> bool:
+    """Return True when the ADK/native tool-call path failed on malformed JSON."""
+    pending = [exc]
+    seen: set[int] = set()
+
+    while pending:
+        current = pending.pop()
+        current_id = id(current)
+        if current_id in seen:
+            continue
+        seen.add(current_id)
+
+        if isinstance(current, json.JSONDecodeError):
+            return True
+
+        message = str(current).lower()
+        if (
+            "tool" in message
+            and "json" in message
+            and any(token in message for token in ("decode", "malformed", "invalid", "parse"))
+        ):
+            return True
+
+        if current.__cause__ is not None:
+            pending.append(current.__cause__)
+        if current.__context__ is not None:
+            pending.append(current.__context__)
+
+    return False
+
 
 async def process_prompt(runner, session, user_query: str) -> None:
     """Process a single user prompt through the swarm."""
     content = types.Content(role="user", parts=[types.Part(text=user_query)])
     logger.info(f"Processing prompt: {user_query}", extra={"session_id": session.id})
-
-    events = runner.run_async(session_id=session.id, user_id="swarm_admin", new_message=content)
-
     try:
+        events = runner.run_async(session_id=session.id, user_id="swarm_admin", new_message=content)
         async for event in events:
             if hasattr(event, "content") and event.content and event.content.parts:
                 text = event.content.parts[0].text
                 if text:
+                    print(f"Swarm: {text}")
                     logger.info(f"Swarm response: {text}", extra={"session_id": session.id})
     except Exception as e:
+        if _should_fallback_to_planner(e):
+            logger.warning(
+                "ADK tool-call JSON failure detected; retrying prompt via planner",
+                extra={"session_id": session.id},
+            )
+            try:
+                fallback = await _run_autonomous_prompt_with_tools(user_query)
+            except Exception as fallback_error:
+                logger.exception(
+                    "Planner fallback failed after ADK tool-call JSON failure",
+                    extra={"session_id": session.id},
+                )
+                print(f"Error during planner fallback: {fallback_error}")
+                return
+            if fallback:
+                print(f"Swarm: {fallback}")
+                logger.info(f"Swarm response: {fallback}", extra={"session_id": session.id})
+            else:
+                logger.error(
+                    "Planner fallback returned no response after ADK tool-call JSON failure",
+                    extra={"session_id": session.id},
+                )
+                print("Error during planner fallback: no response produced")
+            return
         logger.exception("Error during swarm execution")
         if "AttributeError" not in str(e):
             logger.error("Error during swarm execution: %s", e)
@@ -135,14 +207,14 @@ async def process_prompt(runner, session, user_query: str) -> None:
 
 async def run_swarm_loop(session_service, session, runner) -> None:
     """Run the swarm in autonomous loop mode, checking for prompts and shutdown."""
-    initial_query = (
-        "First, use 'list_repo_contents' to explore the 'project-chimera' repository. "
-        "Read key files in that repository (like build.gradle.kts or major Kotlin files) to understand its current state. "
-        "Then, identify high-priority improvements or missing features for Project Chimera, "
-        "create structured tasks for them, and start the proactive ideation process. "
-        "Remember: You are the Cognitive Foundry swarm, and Project Chimera is your development target."
-    )
-    await process_prompt(runner, session, initial_query)
+    initial_query = _build_autonomous_prompt("project-chimera")
+    if should_use_planner_for_autonomous_run(Config.OPENROUTER_MODEL):
+        response = await _run_autonomous_prompt_with_tools(initial_query)
+        if response:
+            print(f"Swarm: {response}")
+            logger.info(f"Swarm response: {response}", extra={"session_id": session.id})
+    else:
+        await process_prompt(runner, session, initial_query)
 
     while True:
         if is_shutdown_requested():
@@ -187,6 +259,9 @@ async def main():
     # Clear any stale shutdown sentinel from previous runs
     clear_shutdown()
     write_pid()
+
+    # Wire up LiteLLM observability callbacks
+    setup_callbacks()
 
     try:
         # 1. Initialize services

--- a/src/observability/litellm_callbacks.py
+++ b/src/observability/litellm_callbacks.py
@@ -1,0 +1,46 @@
+import os
+from importlib.util import find_spec
+
+import litellm
+from src.config import get_settings
+
+
+def _module_available(module_name: str) -> bool:
+    return find_spec(module_name) is not None
+
+def setup_callbacks() -> None:
+    """Configures global LiteLLM callbacks based on environment variables and settings."""
+    settings = get_settings()
+    
+    # Langfuse/Lunary tracing
+    if (os.getenv("LANGFUSE_PUBLIC_KEY") or settings.langfuse_enabled) and _module_available("langfuse"):
+        if "langfuse" not in litellm.success_callback:
+            litellm.success_callback.append("langfuse")
+        if "langfuse" not in litellm.failure_callback:
+            litellm.failure_callback.append("langfuse")
+            
+    # Helicone cost tracking
+    if os.getenv("HELICONE_API_KEY") or settings.helicone_enabled:
+        if "helicone" not in litellm.success_callback:
+            litellm.success_callback.append("helicone")
+            
+    # AgentOps tracing
+    if os.getenv("AGENTOPS_API_KEY") or settings.agentops_enabled:
+        if "agentops" not in litellm.success_callback:
+            litellm.success_callback.append("agentops")
+        if "agentops" not in litellm.failure_callback:
+            litellm.failure_callback.append("agentops")
+            
+    # MLflow experiment tracking
+    if settings.mlflow_enabled:
+        if "mlflow" not in litellm.success_callback:
+            litellm.success_callback.append("mlflow")
+        if "mlflow" not in litellm.failure_callback:
+            litellm.failure_callback.append("mlflow")
+
+    # Sentry exception tracking
+    if settings.sentry_dsn:
+        import sentry_sdk
+        sentry_sdk.init(dsn=settings.sentry_dsn)
+        if "sentry" not in litellm.failure_callback:
+            litellm.failure_callback.append("sentry")

--- a/src/planner.py
+++ b/src/planner.py
@@ -397,11 +397,16 @@ async def run_planner(
     Returns:
         Final text response from the LLM after all tools are resolved.
     """
+    if max_iterations <= 0:
+        return ""
+
     suffix = _build_tool_suffix(allowed_tools)
     messages = [
         {"role": "system", "content": system_prompt + suffix},
         {"role": "user", "content": user_prompt},
     ]
+    text = ""
+    last_result_text = ""
 
     for iteration in range(max_iterations):
         logger.info(f"Planner iteration {iteration + 1}/{max_iterations}")
@@ -431,10 +436,26 @@ async def run_planner(
             f"Tool '{r.get('tool_name')}': {r.get('status')} → {r.get('output', r.get('message', ''))}"
             for r in results
         )
+        last_result_text = result_text
         messages.append({"role": "user", "content": f"Tool results:\n{result_text}"})
 
-    logger.warning("Max iterations reached. Returning last response.")
-    return text
+    logger.warning("Max iterations reached. Requesting final response without more tool calls.")
+    final_messages = messages + [
+        {
+            "role": "user",
+            "content": (
+                "You have received the latest tool results. "
+                "Respond with a final plain-text answer now. "
+                "Do not call any more tools or return JSON."
+            ),
+        }
+    ]
+    final_text = await _llm_turn(final_messages, model=model, retries=Config.LLM_RETRIES)
+    if final_text and not _parse_tool_calls(final_text):
+        return final_text
+
+    logger.warning("Planner finalization still returned tool calls. Returning latest tool results instead.")
+    return last_result_text or text
 
 
 async def run_planner_structured(

--- a/src/services/runtime_strategy.py
+++ b/src/services/runtime_strategy.py
@@ -1,0 +1,3 @@
+def should_use_planner_for_autonomous_run(model_name: str) -> bool:
+    """Return whether autonomous runs should bypass native ADK tool calling."""
+    return model_name.startswith("openrouter/elephant")

--- a/tests/observability/test_litellm_callbacks.py
+++ b/tests/observability/test_litellm_callbacks.py
@@ -1,0 +1,22 @@
+import litellm
+import os
+from src.observability.litellm_callbacks import setup_callbacks
+
+
+def test_callbacks_are_registered_in_litellm(monkeypatch):
+    litellm.success_callback = []
+    litellm.failure_callback = []
+    monkeypatch.setattr(
+        "src.observability.litellm_callbacks._module_available",
+        lambda module_name: True,
+    )
+
+    # Setup dummy env for activation to ensure the branches are hit
+    os.environ["LANGFUSE_PUBLIC_KEY"] = "pk-123"
+    os.environ["HELICONE_API_KEY"] = "sk-123"
+    
+    setup_callbacks()
+    
+    assert "langfuse" in litellm.success_callback
+    assert "langfuse" in litellm.failure_callback
+    assert "helicone" in litellm.success_callback

--- a/tests/runtime/test_autonomous_runtime.py
+++ b/tests/runtime/test_autonomous_runtime.py
@@ -1,0 +1,216 @@
+import json
+
+import pytest
+
+import src.main as main_module
+from src.agents.ideator import ideator_agent
+from src.agents.orchestrator import orchestrator_agent
+from src.main import _build_autonomous_prompt
+from src.services.runtime_strategy import should_use_planner_for_autonomous_run
+
+
+def test_autonomous_runtime_uses_planner_for_elephant_openrouter():
+    assert should_use_planner_for_autonomous_run("openrouter/elephant-alpha") is True
+
+
+def test_orchestrator_instruction_mentions_remote_repo_tools():
+    instruction = orchestrator_agent.instruction
+    assert "read_repo_file" in instruction
+    assert "list_repo_contents" in instruction
+
+
+def test_instruction_surface_uses_remote_repo_tools_not_fake_capabilities():
+    orchestrator_text = orchestrator_agent.instruction
+    ideator_text = ideator_agent.instruction
+
+    assert "read_repo_file and list_repo_contents directly" in orchestrator_text
+    assert "not for browsing the remote GitHub repository" in orchestrator_text
+    assert "only for local specs, plans, and history" in orchestrator_text
+
+    assert "start with 'list_repo_contents'" in ideator_text
+    assert "inspect files with 'read_repo_file'" in ideator_text
+    assert "Use 'list_directory' and 'read_file' only for local workspace files." in ideator_text
+    assert "Do not use retrieve_planning_context or execute_capability to explore the remote repository" in ideator_text
+
+
+def test_autonomous_prompt_uses_registered_remote_repo_tools():
+    prompt = _build_autonomous_prompt("project-chimera")
+    assert "list_repo_contents" in prompt
+    assert "read_repo_file" in prompt
+
+
+@pytest.mark.asyncio
+async def test_process_prompt_uses_planner_for_autonomous_runs(monkeypatch):
+    calls = []
+
+    async def fake_run_planner(*, user_prompt: str, system_prompt: str, max_iterations: int):
+        calls.append((user_prompt, system_prompt, max_iterations))
+        return "DONE"
+
+    monkeypatch.setattr(main_module, "run_planner", fake_run_planner)
+
+    result = await main_module._run_autonomous_prompt_with_tools("prompt text")
+
+    assert result == "DONE"
+    assert calls == [("prompt text", main_module.AUTONOMOUS_SYSTEM_PROMPT, 8)]
+
+
+@pytest.mark.asyncio
+async def test_run_swarm_loop_routes_initial_prompt_through_planner(monkeypatch):
+    prompts = []
+
+    async def fake_run_autonomous_prompt_with_tools(user_prompt: str) -> str:
+        prompts.append(user_prompt)
+        return "planner response"
+
+    monkeypatch.setattr(main_module, "_run_autonomous_prompt_with_tools", fake_run_autonomous_prompt_with_tools)
+    monkeypatch.setattr(main_module, "should_use_planner_for_autonomous_run", lambda model_name: True)
+    monkeypatch.setattr(main_module, "is_shutdown_requested", lambda: True)
+    monkeypatch.setattr(main_module, "dequeue_prompts", lambda: [])
+
+    await main_module.run_swarm_loop(
+        session_service=None,
+        session=type("Session", (), {"id": "session-1"})(),
+        runner=object(),
+    )
+
+    assert prompts == [main_module._build_autonomous_prompt("project-chimera")]
+
+
+@pytest.mark.asyncio
+async def test_process_prompt_falls_back_on_tool_call_json_decode_error(monkeypatch, capsys):
+    class BrokenRunner:
+        def run_async(self, **kwargs):
+            async def _events():
+                raise json.JSONDecodeError("bad tool call", "{", 1)
+                yield
+
+            return _events()
+
+    fallback_calls = []
+
+    async def fake_run_autonomous_prompt_with_tools(user_prompt: str) -> str:
+        fallback_calls.append(user_prompt)
+        return "recovered"
+
+    monkeypatch.setattr(
+        main_module,
+        "_run_autonomous_prompt_with_tools",
+        fake_run_autonomous_prompt_with_tools,
+    )
+
+    await main_module.process_prompt(BrokenRunner(), type("S", (), {"id": "s1"})(), "prompt text")
+
+    captured = capsys.readouterr()
+    assert fallback_calls == ["prompt text"]
+    assert "Swarm: recovered" in captured.out
+
+
+@pytest.mark.asyncio
+async def test_process_prompt_falls_back_on_wrapped_tool_call_json_error(monkeypatch, capsys):
+    class BrokenRunner:
+        def run_async(self, **kwargs):
+            async def _events():
+                raise RuntimeError("Malformed tool-call JSON returned by ADK") from json.JSONDecodeError(
+                    "bad tool call",
+                    "{",
+                    1,
+                )
+                yield
+
+            return _events()
+
+    fallback_calls = []
+
+    async def fake_run_autonomous_prompt_with_tools(user_prompt: str) -> str:
+        fallback_calls.append(user_prompt)
+        return "wrapped recovery"
+
+    monkeypatch.setattr(
+        main_module,
+        "_run_autonomous_prompt_with_tools",
+        fake_run_autonomous_prompt_with_tools,
+    )
+
+    await main_module.process_prompt(BrokenRunner(), type("S", (), {"id": "s2"})(), "prompt text")
+
+    captured = capsys.readouterr()
+    assert fallback_calls == ["prompt text"]
+    assert "Swarm: wrapped recovery" in captured.out
+
+
+@pytest.mark.asyncio
+async def test_process_prompt_does_not_fallback_on_unrelated_exception(monkeypatch):
+    class BrokenRunner:
+        def run_async(self, **kwargs):
+            async def _events():
+                raise RuntimeError("upstream timeout")
+                yield
+
+            return _events()
+
+    fallback_calls = []
+
+    async def fake_run_autonomous_prompt_with_tools(user_prompt: str) -> str:
+        fallback_calls.append(user_prompt)
+        return "should not run"
+
+    monkeypatch.setattr(
+        main_module,
+        "_run_autonomous_prompt_with_tools",
+        fake_run_autonomous_prompt_with_tools,
+    )
+
+    await main_module.process_prompt(BrokenRunner(), type("S", (), {"id": "s3"})(), "prompt text")
+
+    assert fallback_calls == []
+
+
+@pytest.mark.asyncio
+async def test_process_prompt_reports_empty_planner_fallback(monkeypatch, capsys):
+    class BrokenRunner:
+        def run_async(self, **kwargs):
+            async def _events():
+                raise json.JSONDecodeError("bad tool call", "{", 1)
+                yield
+
+            return _events()
+
+    async def fake_run_autonomous_prompt_with_tools(user_prompt: str) -> str:
+        return ""
+
+    monkeypatch.setattr(
+        main_module,
+        "_run_autonomous_prompt_with_tools",
+        fake_run_autonomous_prompt_with_tools,
+    )
+
+    await main_module.process_prompt(BrokenRunner(), type("S", (), {"id": "s4"})(), "prompt text")
+
+    captured = capsys.readouterr()
+    assert "Error during planner fallback: no response produced" in captured.out
+
+
+@pytest.mark.asyncio
+async def test_process_prompt_reports_planner_fallback_failure(monkeypatch, capsys):
+    class BrokenRunner:
+        def run_async(self, **kwargs):
+            async def _events():
+                raise json.JSONDecodeError("bad tool call", "{", 1)
+                yield
+
+            return _events()
+
+    async def fake_run_autonomous_prompt_with_tools(user_prompt: str) -> str:
+        raise RuntimeError("planner crashed")
+
+    monkeypatch.setattr(
+        main_module,
+        "_run_autonomous_prompt_with_tools",
+        fake_run_autonomous_prompt_with_tools,
+    )
+
+    await main_module.process_prompt(BrokenRunner(), type("S", (), {"id": "s5"})(), "prompt text")
+
+    captured = capsys.readouterr()
+    assert "Error during planner fallback: planner crashed" in captured.out

--- a/tests/test_planner_contracts.py
+++ b/tests/test_planner_contracts.py
@@ -65,3 +65,44 @@ async def test_llm_turn_retries_empty_response(monkeypatch):
 
     assert content == "final response"
     assert mocked_completion.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_run_planner_finalizes_after_terminal_tool_call(monkeypatch):
+    mocked_turn = AsyncMock(
+        side_effect=[
+            '```json\n{"action": "read_file", "arguments": {"path": "README.md"}}\n```',
+            "Final summary after reading the file.",
+        ]
+    )
+    mocked_execute = AsyncMock(
+        return_value={
+            "status": "success",
+            "tool_name": "read_file",
+            "output": "README contents",
+        }
+    )
+
+    monkeypatch.setattr(planner, "_llm_turn", mocked_turn)
+    monkeypatch.setattr(planner, "_execute_tool_call", mocked_execute)
+
+    result = await planner.run_planner(
+        user_prompt="Inspect the README and summarize it.",
+        system_prompt="You are a helpful assistant.",
+        max_iterations=1,
+    )
+
+    assert result == "Final summary after reading the file."
+    assert mocked_execute.await_count == 1
+    assert mocked_turn.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_run_planner_with_zero_iterations_returns_empty_string():
+    result = await planner.run_planner(
+        user_prompt="Do nothing.",
+        system_prompt="You are a helpful assistant.",
+        max_iterations=0,
+    )
+
+    assert result == ""

--- a/tests/test_runtime_capabilities.py
+++ b/tests/test_runtime_capabilities.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 import pytest
 
+import src.main as main_module
 from src.tools.dispatcher import batch_execute, execute_capability
 
 
@@ -68,6 +69,48 @@ class TestRuntimeCapabilities:
                 },
             }
         ]
+
+    @pytest.mark.asyncio
+    async def test_planning_retrieval_capability_offloads_retrieve_context(self, monkeypatch):
+        retrieve_calls: list[object] = []
+        to_thread_calls: list[tuple[object, object]] = []
+
+        expected_payload = {
+            "query": "planner contracts",
+            "corpus": ["specs"],
+            "sources": [{"path": "docs/superpowers/specs/spec-a.md", "corpus": "specs"}],
+        }
+
+        def fake_retrieve_context(query: object) -> dict[str, object]:
+            retrieve_calls.append(query)
+            return expected_payload
+
+        async def fake_to_thread(func: object, query: object) -> dict[str, object]:
+            assert retrieve_calls == []
+            to_thread_calls.append((func, query))
+            return func(query)
+
+        monkeypatch.setattr(main_module, "retrieve_context", fake_retrieve_context)
+        monkeypatch.setattr(main_module.asyncio, "to_thread", fake_to_thread)
+
+        result = await execute_capability(
+            main_module.PLANNING_RETRIEVAL_CAPABILITY,
+            query="planner contracts",
+            corpus=["specs"],
+        )
+
+        assert len(to_thread_calls) == 1
+        func, query = to_thread_calls[0]
+        assert func is fake_retrieve_context
+        assert query == main_module.RetrievalQuery(query="planner contracts", corpus=["specs"])
+        assert retrieve_calls == [query]
+        assert result == {
+            "status": "success",
+            "payload": expected_payload,
+            "error": None,
+            "source_backend": "retrieval",
+            "retryable": False,
+        }
 
     def test_orchestrator_instruction_prefers_capabilities(self):
         orchestrator_source = Path("src/agents/orchestrator.py").read_text(encoding="utf-8")

--- a/tests/test_sub_agents.py
+++ b/tests/test_sub_agents.py
@@ -1,3 +1,4 @@
+import pytest
 from src.agents.builder import builder_agent
 from src.agents.critic import critic_agent
 from src.agents.finops import finops_agent


### PR DESCRIPTION
## Summary
- route autonomous startup and malformed ADK tool-call failures through the planner path
- align autonomous repo exploration guidance with the real remote repo tools
- finalize planner runs after terminal tool calls and add regression coverage

## Testing
- /home/westonaaron675/gadk/venv/bin/python -m pytest tests/runtime/test_autonomous_runtime.py tests/test_planner_contracts.py tests/test_runtime_capabilities.py tests/test_sub_agents.py tests/observability/test_litellm_callbacks.py -q