### PR TITLE
feat(sdlc): wire Architect ADR synthesis into autonomous run_cycle (Batch F)

### DIFF
--- a/src/autonomous_sdlc.py
+++ b/src/autonomous_sdlc.py
@@ -35,6 +35,7 @@ def _slugify_task_id(prefix: str, title: str, max_len: int = 40) -> str:
     return task_id
 
 
+from src.agents.architect import draft_architecture_note
 from src.agents.governor import register_external_gate
 from src.config import Config
 from src.observability.logger import configure_logging, get_logger, set_trace_id
@@ -66,6 +67,53 @@ CYCLE_SLEEP_SEC = int(os.getenv("CYCLE_SLEEP_SEC", "30"))
 SHUTDOWN_FILE = os.getenv("SHUTDOWN_FILE", ".shutdown_sdlc")
 TASKS_FILE = "docs/sdlc_tasks.json"
 MAX_REVIEW_RETRIES = int(os.getenv("MAX_REVIEW_RETRIES", "2"))
+
+
+def _architecture_note_from_task(task: dict) -> dict | None:
+    """Synthesize a minimal ADR payload from an Ideator-produced task.
+
+    No LLM call — the ADR is derived from task fields already in hand.
+    Captures the Ideator→Builder handoff in structured form so
+    ``events.jsonl`` carries an auditable rationale for every
+    ARCHITECT transition. A future iteration can swap this for a real
+    Architect-agent LLM roundtrip; the `draft_architecture_note`
+    signature already matches.
+
+    Returns ``None`` if validation fails (e.g., missing required
+    fields) so the caller can degrade to a forced-skip rather than
+    halting the cycle.
+    """
+    try:
+        title = (task.get("title") or "").strip()
+        description = (task.get("description") or "").strip()
+        priority = (task.get("priority") or "MEDIUM").strip().upper()
+        file_hint = (task.get("file_hint") or "").strip()
+
+        if not title or not description:
+            return None
+
+        touched = [file_hint] if file_hint else []
+        consequences = [
+            f"Priority: {priority}",
+            "Implemented by the Builder agent; delivered through the autonomous SDLC loop.",
+        ]
+
+        return draft_architecture_note(
+            task_id=task["task_id"],
+            title=title,
+            context=description,
+            decision="Implement as specified by the Ideator; no additional architectural divergence.",
+            consequences=consequences,
+            alternatives=["Defer: leave the gap unaddressed for the next discovery cycle."],
+            touched_paths=touched,
+        )
+    except Exception as exc:  # pydantic.ValidationError + anything else
+        logger.warning(
+            "architecture.note.degraded task=%s reason=%s",
+            task.get("task_id"),
+            exc,
+        )
+        return None
 
 
 def _extract_review_status(review_text: str) -> str:
@@ -101,12 +149,16 @@ class AutonomousSDLCEngine:
     audit. The discovery + delivery logic is unchanged; only the
     orchestration around it is now observable.
 
-    The `ARCHITECT` phase is bypassed with `force=True` for now — the
-    Architect agent isn't wired into autonomous runs, and running an
-    architecture-note draft would double LLM cost per cycle without
-    improving the outcome. A future cycle can unblock this by wiring
-    `src.agents.architect.draft_architecture_note` before the IMPLEMENT
-    transition.
+    The `ARCHITECT` phase produces a minimal ADR from task fields via
+    :func:`_architecture_note_from_task` — no extra LLM call. The ADR
+    captures the Ideator→Builder handoff in structured form so every
+    transition in ``events.jsonl`` carries an auditable rationale. If
+    the ADR synthesis fails (missing task fields, pydantic validation
+    error), the transition degrades to a forced-skip with a structured
+    warning; the cycle continues rather than halting on the audit
+    surface. A future iteration can replace the synthesis with a real
+    Architect-agent LLM call; the signature already matches
+    :func:`src.agents.architect.draft_architecture_note`.
     """
 
     def __init__(
@@ -458,11 +510,23 @@ class AutonomousSDLCEngine:
         item: WorkItem = ensure_work_item(self.sm, task["task_id"], phase=Phase.PLAN)
         item.payload["task"] = task
 
-        # PLAN → ARCHITECT. Forced skip: Architect agent isn't wired
-        # into autonomous runs yet (see class docstring).
-        self.controller.advance(
-            item, Phase.ARCHITECT, reason="auto-skip: architect agent not wired", force=True
-        )
+        # PLAN → ARCHITECT. Build a minimal ADR from task fields (no
+        # extra LLM call) so every autonomous transition carries a
+        # structured rationale. If synthesis fails (malformed task,
+        # missing fields) we degrade to a forced skip with a
+        # `architecture.note.degraded` warning — the cycle continues
+        # rather than halting on what is meant to be an audit surface.
+        adr = _architecture_note_from_task(task)
+        if adr is not None:
+            item.payload["architecture"] = adr
+            self.controller.advance(item, Phase.ARCHITECT, reason=f"ADR drafted: {adr['title']}")
+        else:
+            self.controller.advance(
+                item,
+                Phase.ARCHITECT,
+                reason="auto-skip: ADR synthesis unavailable",
+                force=True,
+            )
 
         # ARCHITECT → IMPLEMENT (build).
         artifact = await self._build(task)

--- a/test_metrics.jsonl
+++ b/test_metrics.jsonl
@@ -4,42 +4,42 @@
     "TestTool": {
       "calls_total": 1,
       "errors_total": 0,
-      "duration_seconds_sum": 1.2269999842828838e-06,
+      "duration_seconds_sum": 1.0539999948377954e-06,
       "duration_seconds_count": 1,
       "last_error": ""
     },
     "ReadFile": {
       "calls_total": 9,
       "errors_total": 7,
-      "duration_seconds_sum": 0.009351796999794715,
+      "duration_seconds_sum": 0.005624165000085668,
       "duration_seconds_count": 9,
       "last_error": "Path cannot be empty."
     },
     "WriteFile": {
       "calls_total": 9,
       "errors_total": 5,
-      "duration_seconds_sum": 0.015492612999992161,
+      "duration_seconds_sum": 0.008471371000155159,
       "duration_seconds_count": 9,
       "last_error": "Content size (500001 bytes) exceeds write limit of 500000 bytes."
     },
     "ListDirectory": {
       "calls_total": 5,
       "errors_total": 3,
-      "duration_seconds_sum": 0.007277808000026198,
+      "duration_seconds_sum": 0.0038260389999322797,
       "duration_seconds_count": 5,
       "last_error": "Path traversal outside project root is not allowed: ../etc"
     },
     "GitHubTool": {
       "calls_total": 3,
       "errors_total": 0,
-      "duration_seconds_sum": 0.02063877000011871,
+      "duration_seconds_sum": 0.01269812499992895,
       "duration_seconds_count": 3,
       "last_error": ""
     },
     "SandboxExecutor": {
       "calls_total": 3,
       "errors_total": 0,
-      "duration_seconds_sum": 1.0320541509998975,
+      "duration_seconds_sum": 1.0321980129999702,
       "duration_seconds_count": 3,
       "last_error": ""
     }

--- a/tests/test_autonomous_sdlc_phase_gated.py
+++ b/tests/test_autonomous_sdlc_phase_gated.py
@@ -378,3 +378,147 @@ def test_legacy_modules_are_deleted() -> None:
     ):
         with pytest.raises(ModuleNotFoundError):
             importlib.import_module(modname)
+
+
+# ---------------------------------------------------------------------------
+# Batch F: ARCHITECT-phase ADR synthesis
+# ---------------------------------------------------------------------------
+
+
+def test_architecture_note_from_task_produces_valid_adr() -> None:
+    """Happy path: task with title + description + priority yields a
+    populated ADR payload with the expected audit fields."""
+    from src.autonomous_sdlc import _architecture_note_from_task
+
+    adr = _architecture_note_from_task(
+        {
+            "task_id": "sdlc-add-x",
+            "title": "Add X to Y",
+            "description": "The X feature is missing from Y.",
+            "priority": "HIGH",
+            "file_hint": "src/y.py",
+        }
+    )
+    assert adr is not None
+    assert adr["title"] == "Add X to Y"
+    assert "X feature is missing" in adr["context"]
+    assert any("HIGH" in c for c in adr["consequences"])
+    assert adr["touched_paths"] == ["src/y.py"]
+    assert adr["alternatives_considered"]
+
+
+def test_architecture_note_from_task_returns_none_when_missing_fields() -> None:
+    """Degraded path: tasks that lack the minimum fields for an ADR
+    are rejected, so the caller can degrade to a forced-skip rather
+    than halt the cycle with a pydantic ValidationError."""
+    from src.autonomous_sdlc import _architecture_note_from_task
+
+    # Missing title
+    assert _architecture_note_from_task({"task_id": "x", "description": "d"}) is None
+    # Missing description
+    assert _architecture_note_from_task({"task_id": "x", "title": "t"}) is None
+    # Blank title and description
+    assert _architecture_note_from_task({"task_id": "x", "title": "", "description": ""}) is None
+
+
+@pytest.mark.asyncio
+async def test_run_cycle_stores_adr_in_payload(
+    engine_with_mocks, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The ARCHITECT transition stashes the synthesized ADR on the
+    WorkItem so the audit trail ties each PR back to its rationale."""
+    engine, _ = engine_with_mocks
+
+    async def _discover() -> list[dict]:
+        return [
+            {
+                "title": "Add retries",
+                "priority": "HIGH",
+                "description": "dispatch needs retries",
+                "file_hint": "src/tools/dispatcher.py",
+            }
+        ]
+
+    async def _plan(tasks: list) -> dict:
+        return {
+            "task_id": "sdlc-retries",
+            "title": "Add retries",
+            "priority": "HIGH",
+            "description": "dispatch needs retries",
+            "file_hint": "src/tools/dispatcher.py",
+        }
+
+    async def _build(task: dict) -> str:
+        return "src/staged_agents/retries.py"
+
+    async def _review(artifact: str, task: dict) -> str:
+        return "Status: pass"
+
+    async def _deliver(artifact: str, task: dict, review: str) -> str:
+        return "https://example/pr/1"
+
+    for name, fn in {
+        "_discover": _discover,
+        "_plan": _plan,
+        "_build": _build,
+        "_review": _review,
+        "_deliver": _deliver,
+    }.items():
+        monkeypatch.setattr(engine, name, fn)
+
+    result = await engine.run_cycle()
+    assert result is True
+
+    item = load_work_item(engine.sm, "sdlc-retries")
+    assert item is not None
+    assert "architecture" in item.payload
+    assert item.payload["architecture"]["title"] == "Add retries"
+    assert item.payload["architecture"]["touched_paths"] == ["src/tools/dispatcher.py"]
+
+
+@pytest.mark.asyncio
+async def test_run_cycle_degrades_when_adr_synthesis_fails(
+    engine_with_mocks, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A task with missing description should force-skip ARCHITECT
+    (emits the degraded warning) but still advance the cycle. The
+    skip must still emit a `phase.transition` event so the audit
+    trail shows the ARCHITECT step happened."""
+    engine, events_file = engine_with_mocks
+
+    async def _discover() -> list[dict]:
+        return [{"title": "X", "priority": "HIGH"}]  # no description
+
+    async def _plan(tasks: list) -> dict:
+        # task_id present, title present, description MISSING → ADR fails
+        return {"task_id": "sdlc-no-desc", "title": "X", "priority": "HIGH"}
+
+    async def _build(task: dict) -> str:
+        return "src/staged_agents/x.py"
+
+    async def _review(artifact: str, task: dict) -> str:
+        return "Status: pass"
+
+    async def _deliver(artifact: str, task: dict, review: str) -> str:
+        return "https://example/pr/2"
+
+    for name, fn in {
+        "_discover": _discover,
+        "_plan": _plan,
+        "_build": _build,
+        "_review": _review,
+        "_deliver": _deliver,
+    }.items():
+        monkeypatch.setattr(engine, name, fn)
+
+    result = await engine.run_cycle()
+    assert result is True  # cycle completes despite ADR synthesis failure
+
+    item = load_work_item(engine.sm, "sdlc-no-desc")
+    assert item is not None
+    # ARCHITECT transition still fired (forced skip).
+    events = _read_events(events_file)
+    targets = [e.get("to_phase") for e in events if e.get("action") == "phase.transition"]
+    assert "ARCHITECT" in targets
+    # But payload has no `architecture` key since synthesis degraded.
+    assert "architecture" not in item.payload


### PR DESCRIPTION
**Batch F** — closes the deferred loose-end from PR #32 ("Wire Architect agent into autonomous runs"). The ARCHITECT phase was previously a forced skip because the Architect agent wasn't wired in, leaving a gap in the audit trail since every cycle transitioned through ARCHITECT with no captured rationale.

**Fix**: synthesize a minimal ADR from task fields (no extra LLM call).

## Changes

### `src/autonomous_sdlc.py`

- New **`_architecture_note_from_task(task)`** helper — builds a validated `ArchitectureNote` payload via `draft_architecture_note` using the Ideator-produced `title` / `description` / `priority` / `file_hint`. Returns `None` on validation failure so the caller can degrade to `force=True` rather than halting the cycle.
- `run_cycle` now calls the helper before the PLAN→ARCHITECT advance:
  - **Happy path**: ADR stashed in `item.payload["architecture"]`, transition reason includes the ADR title.
  - **Degraded path**: structured `architecture.note.degraded` warning fires, transition still runs with `force=True` so the cycle completes.
- Class docstring updated.

### `tests/test_autonomous_sdlc_phase_gated.py` (+4 tests, 13 total)

- `test_architecture_note_from_task_produces_valid_adr` — happy-path helper returns a populated ADR.
- `test_architecture_note_from_task_returns_none_when_missing_fields` — missing title/description → `None`, not a raise.
- `test_run_cycle_stores_adr_in_payload` — end-to-end cycle attaches the ADR to the WorkItem.
- `test_run_cycle_degrades_when_adr_synthesis_fails` — cycle still completes and ARCHITECT still transitions when synthesis fails.

## Tests

- [x] `pytest -q` — **293 passing / 2 skipped** on the stable subset.
- [x] `ruff check src tests` — clean.
- [x] `ruff format --check src tests` — clean.
- [x] `coverage report --fail-under=45` — passes.
- [ ] CI run on this PR.

## Notes

- **No LLM call added per cycle.** The ADR is synthesized from fields already in hand. Swapping the synthesis for a real Architect-agent LLM call in a future iteration only requires changing the helper; the downstream `draft_architecture_note` signature already matches.
- Depends on `draft_architecture_note` from `src.agents.architect` (PR #2, merged).
- Builds on the phase-gated engine from PR #32 (just merged).

https://claude.ai/code/session_01665TpXDGRoB8ipxn8n3on5